### PR TITLE
Enable Preemptive Authentication by default, but allow disabling.

### DIFF
--- a/tcwebhooks-core/src/main/java/webhook/teamcity/auth/UsernamePasswordAuthenticator.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/auth/UsernamePasswordAuthenticator.java
@@ -30,6 +30,7 @@ public class UsernamePasswordAuthenticator implements WebHookAuthenticator {
 					}
 					Credentials creds = new UsernamePasswordCredentials(config.parameters.get(USERNAME), config.parameters.get(PASSWORD));
 					client.getState().setCredentials(scope, creds);
+					client.getParams().setAuthenticationPreemptive(config.preemptive);
 			}
 		}
 

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/auth/WebHookAuthConfig.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/auth/WebHookAuthConfig.java
@@ -5,5 +5,6 @@ import java.util.TreeMap;
 
 public class WebHookAuthConfig {
 	public String type = "";
+	public Boolean preemptive = true;
 	public Map<String, String> parameters = new TreeMap<String, String>();
 }

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookConfig.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookConfig.java
@@ -44,6 +44,7 @@ public class WebHookConfig {
 	private String authType = "";
 	private Boolean authEnabled = false;
 	private SortedMap<String,String> authParameters;
+	private Boolean authPreemptive = false;
 	
 	@SuppressWarnings("unchecked")
 	public WebHookConfig (Element e) {
@@ -162,6 +163,15 @@ public class WebHookConfig {
 					// to true anyway (since we have the auth type).
 					authEnabled = true;
 				}
+				try {
+					if (eAuth.getAttribute("preemptive") != null){
+						authPreemptive = eAuth.getAttribute("preemptive").getBooleanValue();
+					}
+				} catch (DataConversionException e1){
+					// And if it can't be read as boolean default it 
+					// to true (which means creds are always sent).
+					authPreemptive = true;
+				}
 				Element eParams = eAuth.getChild("auth-parameters");
 				if (eParams != null){
 					List<Element> paramsList = eParams.getChildren("param");
@@ -266,6 +276,7 @@ public class WebHookConfig {
 			Element authEl = new Element("auth");
 			authEl.setAttribute("enabled", this.authEnabled.toString());
 			authEl.setAttribute("type", this.authType);
+			authEl.setAttribute("preemptive", this.authPreemptive.toString() );
 			if (this.authParameters.size() > 0){
 				Element paramsEl = new Element("auth-parameters");
 				for (String i : this.authParameters.keySet()){
@@ -531,6 +542,7 @@ public class WebHookConfig {
 		if (authEnabled && !authType.equals("")){
 			WebHookAuthConfig webhookAuthConfig= new WebHookAuthConfig();
 			webhookAuthConfig.type = authType;
+			webhookAuthConfig.preemptive = authPreemptive;
 			webhookAuthConfig.parameters.putAll(authParameters);
 			return webhookAuthConfig;
 		}

--- a/tcwebhooks-core/src/test/java/webhook/WebHookTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/WebHookTest.java
@@ -134,6 +134,7 @@ public class WebHookTest{
 		UsernamePasswordAuthenticator authenticator = new UsernamePasswordAuthenticator();
 		WebHookAuthConfig authConfig = new WebHookAuthConfig();
 		authConfig.type = "userPass";
+		authConfig.preemptive = false;
 		authConfig.parameters.put("username", "user1");
 		authConfig.parameters.put("password", "user1pass");
 		authConfig.parameters.put("realm", "realmywealmy");
@@ -149,6 +150,30 @@ public class WebHookTest{
 		System.out.println(w.getContent());
 		stopWebServer(s);
 		assertTrue(w.getStatus() == HttpStatus.SC_UNAUTHORIZED);
+	}
+	
+	@Test
+	public void test_200WithAuthPreemptionButWrongRealm() throws FileNotFoundException, IOException, Exception {
+		WebHookTestServer s = startWebServer();
+		WebHook w = factory.getWebHook(url + "/auth/200");
+		UsernamePasswordAuthenticator authenticator = new UsernamePasswordAuthenticator();
+		WebHookAuthConfig authConfig = new WebHookAuthConfig();
+		authConfig.type = "userPass";
+		authConfig.parameters.put("username", "user1");
+		authConfig.parameters.put("password", "user1pass");
+		authConfig.parameters.put("realm", "realmywealmy");
+		authenticator.setWebHookAuthConfig(authConfig);
+		w.setAuthentication(authenticator);
+		
+		w.addParam("buildID", "foobar");
+		w.addParam("notifiedFor", "someUser");
+		w.addParam("buildResult", "failed");
+		w.addParam("triggeredBy", "Subversion");
+		w.setEnabled(true);
+		w.post();
+		System.out.println(w.getContent());
+		stopWebServer(s);
+		assertTrue(w.getStatus() == HttpStatus.SC_OK);
 	}
 	
 	@Test


### PR DESCRIPTION
If a user has bothered to configure authentication credentials
then enable sending those credentials straight away.

Don't wait for a 401 to be returned before sending the creds.

For those who are paranoid, it's possible to disable preemptive
authentication, and then the auth creds will not be sent if the REALM in
the 401 does not match the configured realm.