### PR TITLE
Fix: squid:S2293, The operator <> should be used.

### DIFF
--- a/tcwebhooks-core/src/main/java/webhook/WebHookCollection.java
+++ b/tcwebhooks-core/src/main/java/webhook/WebHookCollection.java
@@ -16,7 +16,7 @@ public class WebHookCollection {
 	private Map <String, String> origParams; 
 	
 	public WebHookCollection(Map <String, String> params) {
-		webHooks = new HashMap<Integer,WebHook>();
+		webHooks = new HashMap<>();
 		this.origParams = params;
 		this.parseParams(params);
 	}

--- a/tcwebhooks-core/src/main/java/webhook/WebHookImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/WebHookImpl.java
@@ -42,19 +42,19 @@ public class WebHookImpl implements WebHook {
 	
 	public WebHookImpl(){
 		this.client = new HttpClient();
-		this.params = new ArrayList<NameValuePair>();
+		this.params = new ArrayList<>();
 	}
 	
 	public WebHookImpl(String url){
 		this.url = url;
 		this.client = new HttpClient();
-		this.params = new ArrayList<NameValuePair>();
+		this.params = new ArrayList<>();
 	}
 	
 	public WebHookImpl (String url, String proxyHost, String proxyPort){
 		this.url = url;
 		this.client = new HttpClient();
-		this.params = new ArrayList<NameValuePair>();
+		this.params = new ArrayList<>();
 		if (proxyPort.length() != 0) {
 			try {
 				this.proxyPort = Integer.parseInt(proxyPort);
@@ -68,14 +68,14 @@ public class WebHookImpl implements WebHook {
 	public WebHookImpl (String url, String proxyHost, Integer proxyPort){
 		this.url = url;
 		this.client = new HttpClient();
-		this.params = new ArrayList<NameValuePair>();
+		this.params = new ArrayList<>();
 		this.setProxy(proxyHost, proxyPort);
 	}
 	
 	public WebHookImpl (String url, WebHookProxyConfig proxyConfig){
 		this.url = url;
 		this.client = new HttpClient();
-		this.params = new ArrayList<NameValuePair>();
+		this.params = new ArrayList<>();
 		setProxy(proxyConfig);
 	}
 

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/BuildState.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/BuildState.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 public class BuildState {
 
-	Map<BuildStateEnum, BuildStateInterface> states = new HashMap<BuildStateEnum, BuildStateInterface>();
+	Map<BuildStateEnum, BuildStateInterface> states = new HashMap<>();
 	
 	public BuildState() {
 		states.clear();

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/WebHookContentBuilder.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/WebHookContentBuilder.java
@@ -114,7 +114,7 @@ public class WebHookContentBuilder {
 	}
 	
 	public static SortedMap<String,String> mergeParameters(SortedMap<String,String> parametersFromConfig, ParametersSupport build, String preferredDateFormat){
-		SortedMap<String, String> newMap = new TreeMap<String,String>();
+		SortedMap<String, String> newMap = new TreeMap<>();
 		
 		// First add the preferredDateFormat from the template. This can then be overriden 
 		// by the webhook config (plugin-settings.xml) 

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/WebHookListener.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/WebHookListener.java
@@ -88,8 +88,8 @@ public class WebHookListener extends BuildServerAdapter {
 	 * @return
 	 */
 	private List<WebHookConfig> getListOfEnabledWebHooks(String projectId) {
-		List<WebHookConfig> configs = new ArrayList<WebHookConfig>();
-		List<SProject> projects = new ArrayList<SProject>();
+		List<WebHookConfig> configs = new ArrayList<>();
+		List<SProject> projects = new ArrayList<>();
 		SProject myProject = myBuildServer.getProjectManager().findProjectById(projectId);
 		projects.addAll(myProject.getProjectPath());
 		for (SProject project : projects){

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/auth/WebHookAuthConfig.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/auth/WebHookAuthConfig.java
@@ -6,5 +6,5 @@ import java.util.TreeMap;
 public class WebHookAuthConfig {
 	public String type = "";
 	public Boolean preemptive = true;
-	public Map<String, String> parameters = new TreeMap<String, String>();
+	public Map<String, String> parameters = new TreeMap<>();
 }

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/auth/WebHookAuthenticatorProvider.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/auth/WebHookAuthenticatorProvider.java
@@ -7,7 +7,7 @@ import webhook.teamcity.Loggers;
 
 public class WebHookAuthenticatorProvider {
 	
-	HashMap<String, WebHookAuthenticatorFactory> types = new HashMap<String,WebHookAuthenticatorFactory>();
+	HashMap<String, WebHookAuthenticatorFactory> types = new HashMap<>();
 	
 	public WebHookAuthenticatorProvider(){
 		Loggers.SERVER.info("WebHookAuthenticatorProvider :: Starting");

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/endpoint/WebHookEndPointContentStore.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/endpoint/WebHookEndPointContentStore.java
@@ -15,7 +15,7 @@ public class WebHookEndPointContentStore {
 	
 	private static final int MAX_SIZE = 100;
 	
-	List<WebHookEndPointPayload> store = new ArrayList<WebHookEndPointPayload>(50);
+	List<WebHookEndPointPayload> store = new ArrayList<>(50);
 	Comparator<WebHookEndPointPayload> dateComparator = new WebHookEndPointContentStoreCompator();
 	final WebHookPayloadManager webHookPayloadManager;
 	
@@ -44,7 +44,7 @@ public class WebHookEndPointContentStore {
 	
 	@Synchronized
 	public List<WebHookEndPointPayload> getAll(){
-		List<WebHookEndPointPayload> sortedStore = new ArrayList<WebHookEndPointPayload>();
+		List<WebHookEndPointPayload> sortedStore = new ArrayList<>();
 		sortedStore.addAll(store);
 		Collections.sort(sortedStore, dateComparator);
 		return sortedStore;

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookPayloadDefaultTemplates.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookPayloadDefaultTemplates.java
@@ -17,7 +17,7 @@ public class WebHookPayloadDefaultTemplates {
 			 "<strong>${buildResult}</strong></a> and was triggered by <strong>${triggeredBy}</strong></span>"; 
 
 	public static Map<String,String> getDefaultEnabledPayloadTemplates(){
-		Map<String,String> mT = new TreeMap<String, String>();
+		Map<String,String> mT = new TreeMap<>();
 		mT.put(HTML_BUILDSTATUS_TEMPLATE, DEFAULT_HTML_BUILDSTATUS_TEMPLATE);
 		return mT;
 	}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookPayloadManager.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookPayloadManager.java
@@ -12,9 +12,9 @@ import webhook.teamcity.Loggers;
 
 public class WebHookPayloadManager {
 	
-	HashMap<String, WebHookPayload> formats = new HashMap<String,WebHookPayload>();
+	HashMap<String, WebHookPayload> formats = new HashMap<>();
 	Comparator<WebHookPayload> rankComparator = new WebHookPayloadRankingComparator();
-	List<WebHookPayload> orderedFormatCollection = new ArrayList<WebHookPayload>();
+	List<WebHookPayload> orderedFormatCollection = new ArrayList<>();
 	SBuildServer server;
 	
 	public WebHookPayloadManager(SBuildServer server){

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookTemplateFileChangeHandler.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookTemplateFileChangeHandler.java
@@ -57,7 +57,7 @@ public class WebHookTemplateFileChangeHandler implements ChangeListener, WebHook
 
 	@Override
 	public void handleConfigFileChange() {
-		List<WebHookTemplate> newTemplates = new ArrayList<WebHookTemplate>();
+		List<WebHookTemplate> newTemplates = new ArrayList<>();
 		try {
 			WebHookTemplates templatesList =  WebHookTemplateJaxHelper.read(configFile.getPath());
 			for (webhook.teamcity.settings.entity.WebHookTemplate template : templatesList.getWebHookTemplateList()){

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookTemplateManager.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookTemplateManager.java
@@ -10,10 +10,10 @@ import webhook.teamcity.Loggers;
 
 public class WebHookTemplateManager {
 	
-	HashMap<String, WebHookTemplate> springTemplates = new HashMap<String,WebHookTemplate>();
-	HashMap<String, WebHookTemplate> xmlConfigTemplates = new HashMap<String,WebHookTemplate>();
+	HashMap<String, WebHookTemplate> springTemplates = new HashMap<>();
+	HashMap<String, WebHookTemplate> xmlConfigTemplates = new HashMap<>();
 	Comparator<WebHookTemplate> rankComparator = new WebHookTemplateRankingComparator();
-	List<WebHookTemplate> orderedTemplateCollection = new ArrayList<WebHookTemplate>();
+	List<WebHookTemplate> orderedTemplateCollection = new ArrayList<>();
 	WebHookPayloadManager webHookPayloadManager;
 	
 	public WebHookTemplateManager(WebHookPayloadManager webHookPayloadManager){
@@ -64,7 +64,7 @@ public class WebHookTemplateManager {
 	private void rebuildOrderedListOfTemplates() {
 		this.orderedTemplateCollection.clear();
 		
-		HashMap<String, WebHookTemplate> combinedTemplates = new HashMap<String,WebHookTemplate>();
+		HashMap<String, WebHookTemplate> combinedTemplates = new HashMap<>();
 		
 		// Rebuild the list of configured templates.
 		// Add all the spring ones.
@@ -104,7 +104,7 @@ public class WebHookTemplateManager {
 	}
 
 	public List<WebHookTemplate> findAllTemplatesForFormat(String formatShortName){
-		List<WebHookTemplate> matchingTemplates = new ArrayList<WebHookTemplate>();
+		List<WebHookTemplate> matchingTemplates = new ArrayList<>();
 		for (WebHookTemplate template : orderedTemplateCollection){
 			if (template.supportsPayloadFormat(formatShortName)){
 				matchingTemplates.add(template);

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHookPayloadContent.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHookPayloadContent.java
@@ -68,7 +68,7 @@ public class WebHookPayloadContent {
 		List<String> buildTags;
 		ExtraParametersMap extraParameters;
 		private ExtraParametersMap teamcityProperties;
-		private List<WebHooksChanges> changes = new ArrayList<WebHooksChanges>();
+		private List<WebHooksChanges> changes = new ArrayList<>();
 		
 		/**
 		 * Constructor: Only called by RepsonsibilityChanged.
@@ -228,7 +228,7 @@ public class WebHookPayloadContent {
 		}
 		
 		private void setTags(List<String> tags) {
-			this.buildTags = new ArrayList<String>();
+			this.buildTags = new ArrayList<>();
 			this.buildTags.addAll(tags);
 		}
 
@@ -406,7 +406,7 @@ public class WebHookPayloadContent {
 
 		public void setBuildRunners(List<SBuildRunnerDescriptor> list) {
 			if (list != null){
-				buildRunners = new ArrayList<String>(); 
+				buildRunners = new ArrayList<>();
 				for (SBuildRunnerDescriptor runner : list){
 					buildRunners.add(runner.getRunType().getDisplayName());
 				}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHooksChange.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHooksChange.java
@@ -20,7 +20,7 @@ public class WebHooksChange {
 	}
 
 
-	private List<String> files = new ArrayList<String>();
+	private List<String> files = new ArrayList<>();
 	private String comment;
 	private String vcsRoot;
 	

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHooksChangeBuilder.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHooksChangeBuilder.java
@@ -8,7 +8,7 @@ import jetbrains.buildServer.vcs.SVcsModification;
 public class WebHooksChangeBuilder{
 	
 	public static List<WebHooksChanges> build (List<SVcsModification> mods){
-		List<WebHooksChanges> changes = new ArrayList<WebHooksChanges>();
+		List<WebHooksChanges> changes = new ArrayList<>();
 		
 		for (SVcsModification modification: mods){
 			changes.add(new WebHooksChanges(modification.getDisplayVersion(), WebHooksChange.build(modification)));

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/template/AbstractFileSetBasedWebHookTemplate.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/template/AbstractFileSetBasedWebHookTemplate.java
@@ -16,8 +16,8 @@ import webhook.teamcity.payload.WebHookTemplateManager;
 
 public abstract class AbstractFileSetBasedWebHookTemplate extends AbstractWebHookTemplate {
 	
-	Map<BuildStateEnum,WebHookTemplateContent> templateContent = new HashMap<BuildStateEnum, WebHookTemplateContent>();
-	Map<BuildStateEnum,WebHookTemplateContent> branchTemplateContent = new HashMap<BuildStateEnum, WebHookTemplateContent>();
+	Map<BuildStateEnum,WebHookTemplateContent> templateContent = new HashMap<>();
+	Map<BuildStateEnum,WebHookTemplateContent> branchTemplateContent = new HashMap<>();
 
 	public abstract String getLoggingName();
 	public abstract String getTemplateFilesLocation();

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/template/AbstractPropertiesBasedWebHookTemplate.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/template/AbstractPropertiesBasedWebHookTemplate.java
@@ -15,8 +15,8 @@ import webhook.teamcity.payload.WebHookTemplateManager;
 
 public abstract class AbstractPropertiesBasedWebHookTemplate extends AbstractWebHookTemplate {
 	
-	Map<BuildStateEnum,WebHookTemplateContent> templateContent = new HashMap<BuildStateEnum, WebHookTemplateContent>();
-	Map<BuildStateEnum,WebHookTemplateContent> branchTemplateContent = new HashMap<BuildStateEnum, WebHookTemplateContent>();
+	Map<BuildStateEnum,WebHookTemplateContent> templateContent = new HashMap<>();
+	Map<BuildStateEnum,WebHookTemplateContent> branchTemplateContent = new HashMap<>();
 
 	public abstract String getLoggingName();
 	public abstract String getPropertiesFileName();

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/template/FlowdockWebHookTemplate.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/template/FlowdockWebHookTemplate.java
@@ -9,8 +9,8 @@ import webhook.teamcity.payload.format.WebHookPayloadJsonTemplate;
 
 public class FlowdockWebHookTemplate extends AbstractFileSetBasedWebHookTemplate {
 
-	private Map<BuildStateEnum, String> normalTemplateMap = new TreeMap<BuildStateEnum, String>();
-	private Map<BuildStateEnum, String> branchTemplateMap = new TreeMap<BuildStateEnum, String>();
+	private Map<BuildStateEnum, String> normalTemplateMap = new TreeMap<>();
+	private Map<BuildStateEnum, String> branchTemplateMap = new TreeMap<>();
 
 	public FlowdockWebHookTemplate(WebHookTemplateManager manager) {
 		super(manager);

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/template/LegacyDeprecatedFormatWebHookTemplate.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/template/LegacyDeprecatedFormatWebHookTemplate.java
@@ -10,7 +10,7 @@ import webhook.teamcity.payload.WebHookTemplateManager;
 
 public class LegacyDeprecatedFormatWebHookTemplate extends AbstractWebHookTemplate implements WebHookTemplate {
 	
-	Set<BuildStateEnum> states = new HashSet<BuildStateEnum>(); 
+	Set<BuildStateEnum> states = new HashSet<>();
 	
 	public LegacyDeprecatedFormatWebHookTemplate(WebHookTemplateManager manager) {
 		super();

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/template/WebHookTemplateFromXml.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/template/WebHookTemplateFromXml.java
@@ -14,9 +14,9 @@ import webhook.teamcity.payload.WebHookTemplateManager;
 
 public class WebHookTemplateFromXml implements WebHookTemplate {
 	
-	List<String> supportedFormats = new ArrayList<String>();
-	Map<BuildStateEnum,WebHookTemplateContent> templateContent = new HashMap<BuildStateEnum, WebHookTemplateContent>();
-	Map<BuildStateEnum,WebHookTemplateContent> branchTemplateContent = new HashMap<BuildStateEnum, WebHookTemplateContent>();
+	List<String> supportedFormats = new ArrayList<>();
+	Map<BuildStateEnum,WebHookTemplateContent> templateContent = new HashMap<>();
+	Map<BuildStateEnum,WebHookTemplateContent> branchTemplateContent = new HashMap<>();
 	
 	protected WebHookTemplateManager manager;
 	private int rank = 10; // Default to 10.

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookConfig.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookConfig.java
@@ -42,7 +42,7 @@ public class WebHookConfig {
 	private SortedMap<String, CustomMessageTemplate> templates; 
 	private Boolean allBuildTypesEnabled = true;
 	private Boolean subProjectsEnabled = true;
-	private Set<String> enabledBuildTypesSet = new HashSet<String>();
+	private Set<String> enabledBuildTypesSet = new HashSet<>();
 	private String authType = "";
 	private Boolean authEnabled = false;
 	private SortedMap<String,String> authParameters;
@@ -54,9 +54,9 @@ public class WebHookConfig {
 		int Min = 1000000, Max = 1000000000;
 		Integer Rand = Min + (int)(Math.random() * ((Max - Min) + 1));
 		this.uniqueKey = Rand.toString();
-		this.extraParameters = new TreeMap<String,String>();
-		this.authParameters = new TreeMap<String,String>();
-		this.templates = new TreeMap<String,CustomMessageTemplate>();
+		this.extraParameters = new TreeMap<>();
+		this.authParameters = new TreeMap<>();
+		this.templates = new TreeMap<>();
 		
 		if (e.getAttribute("url") != null){
 			this.setUrl(e.getAttributeValue("url"));
@@ -212,8 +212,8 @@ public class WebHookConfig {
 		int Min = 1000000, Max = 1000000000;
 		Integer Rand = Min + (int)(Math.random() * ((Max - Min) + 1));
 		this.uniqueKey = Rand.toString();
-		this.extraParameters = new TreeMap<String,String>();
-		this.templates = new TreeMap<String,CustomMessageTemplate>();
+		this.extraParameters = new TreeMap<>();
+		this.templates = new TreeMap<>();
 		this.setUrl(url);
 		this.setEnabled(enabled);
 		this.setBuildStates(states);

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookMainConfig.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookMainConfig.java
@@ -28,8 +28,8 @@ public class WebHookMainConfig {
 	private Pattern singleHostPattern, hostnameOnlyPattern ;
 
 	public WebHookMainConfig() {
-		noProxyUrls = new ArrayList<String>();
-		noProxyPatterns = new ArrayList<Pattern>();
+		noProxyUrls = new ArrayList<>();
+		noProxyPatterns = new ArrayList<>();
 		singleHostPattern = Pattern.compile(SINGLE_HOST_REGEX); 
 		hostnameOnlyPattern = Pattern.compile(HOSTNAME_ONLY_REGEX);
 	}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookProjectSettings.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookProjectSettings.java
@@ -25,7 +25,7 @@ public class WebHookProjectSettings implements ProjectSettings {
 	private CopyOnWriteArrayList<WebHookConfig> webHooksConfigs;
 	
 	public WebHookProjectSettings(){
-		webHooksConfigs = new CopyOnWriteArrayList<WebHookConfig>();
+		webHooksConfigs = new CopyOnWriteArrayList<>();
 	}
 
     @SuppressWarnings("unchecked")
@@ -35,7 +35,7 @@ public class WebHookProjectSettings implements ProjectSettings {
      */
     {
     	Loggers.SERVER.debug("readFrom :: " + rootElement.toString());
-    	CopyOnWriteArrayList<WebHookConfig> configs = new CopyOnWriteArrayList<WebHookConfig>();
+    	CopyOnWriteArrayList<WebHookConfig> configs = new CopyOnWriteArrayList<>();
     	
     	if (rootElement.getAttribute("enabled") != null){
     		this.webHooksEnabled = Boolean.parseBoolean(rootElement.getAttributeValue("enabled"));
@@ -85,7 +85,7 @@ public class WebHookProjectSettings implements ProjectSettings {
     }    
     
     public List<WebHookConfig> getProjectWebHooksAsList(){
-    	List<WebHookConfig> projHooks = new ArrayList<WebHookConfig>();
+    	List<WebHookConfig> projHooks = new ArrayList<>();
     	for (WebHookConfig config : getWebHooksAsList()){
     		if (config.isEnabledForAllBuildsInProject()){
     			projHooks.add(config);
@@ -95,7 +95,7 @@ public class WebHookProjectSettings implements ProjectSettings {
     }    
     
     public List<WebHookConfig> getBuildWebHooksAsList(SBuildType buildType){
-    	List<WebHookConfig> buildHooks = new ArrayList<WebHookConfig>();
+    	List<WebHookConfig> buildHooks = new ArrayList<>();
     	for (WebHookConfig config : getWebHooksAsList()){
     		if (config.isSpecificBuildTypeEnabled(buildType)){
     			buildHooks.add(config);
@@ -119,7 +119,7 @@ public class WebHookProjectSettings implements ProjectSettings {
         {
         	updateSuccess = false;
         	updateMessage = "";
-        	List<WebHookConfig> tempWebHookList = new ArrayList<WebHookConfig>();
+        	List<WebHookConfig> tempWebHookList = new ArrayList<>();
             for(WebHookConfig whc : webHooksConfigs)
             {
                 if (whc.getUniqueKey().equals(webHookId)){

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/entity/WebHookTemplate.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/entity/WebHookTemplate.java
@@ -87,10 +87,10 @@ public class WebHookTemplate {
 	String preferredDateTimeFormat = "";
 	
 	@XmlElement(name="format") @XmlElementWrapper(name="formats")
-	private List<WebHookTemplateFormat> formats = new ArrayList<WebHookTemplateFormat>();
+	private List<WebHookTemplateFormat> formats = new ArrayList<>();
 	
 	@XmlElement(name="template") @XmlElementWrapper(name="templates")
-	private List<WebHookTemplateItem> templates = new ArrayList<WebHookTemplateItem>();
+	private List<WebHookTemplateItem> templates = new ArrayList<>();
 	
 	WebHookTemplate() {
 		// empty constructor for JAXB
@@ -126,7 +126,7 @@ public class WebHookTemplate {
 		boolean enabled = true;
 		
 		@XmlElement(name="state") @XmlElementWrapper(name="states")
-		private List<WebHookTemplateState> states = new ArrayList<WebHookTemplateState>();
+		private List<WebHookTemplateState> states = new ArrayList<>();
 		
 		WebHookTemplateItem() {
 			// empty constructor for JAXB

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/entity/WebHookTemplateJaxHelper.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/entity/WebHookTemplateJaxHelper.java
@@ -70,8 +70,8 @@ public class WebHookTemplateJaxHelper {
 		}
 
 		assert suppliersBean != null;
-		List<String> templateNames = new ArrayList<String>();
-		List<WebHookTemplate> itemsToRemove = new ArrayList<WebHookTemplate>();
+		List<String> templateNames = new ArrayList<>();
+		List<WebHookTemplate> itemsToRemove = new ArrayList<>();
 
 		// Get supplier instance by id. If it's not found - remove it
 		for (WebHookTemplate templateBean : suppliersBean.getWebHookTemplateList()) {

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/entity/WebHookTemplates.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/entity/WebHookTemplates.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 @XmlRootElement(name = "webhook-templates")
 public class WebHookTemplates {
 	@NotNull
-	private List<WebHookTemplate> templateList = new ArrayList<WebHookTemplate>();
+	private List<WebHookTemplate> templateList = new ArrayList<>();
 
 	@NotNull
 	@XmlElement(name = "webhook-template")

--- a/tcwebhooks-core/src/test/java/webhook/WebHookTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/WebHookTest.java
@@ -376,7 +376,7 @@ public class WebHookTest{
 	
 	@Ignore
 	public void test_WebHookCollection() throws WebHookParameterReferenceException {
-		Map <String, String> params = new HashMap<String, String>();
+		Map <String, String> params = new HashMap<>();
 		params.put("system.webhook.1.url", url);
 		params.put("system.webhook.1.enabled", "true");
 		params.put("system.webhook.1.parameter.1.name","fod");
@@ -399,7 +399,7 @@ public class WebHookTest{
 	
 	@Ignore
 	public void test_WebHookCollectionWithRecursiveParameterReference() throws WebHookParameterReferenceException {
-		Map <String, String> params = new HashMap<String, String>();
+		Map <String, String> params = new HashMap<>();
 		params.put("system.test.recursive1", "%system.test.recursive2%");
 		params.put("system.test.recursive2", "blahblah");
 		params.put("system.webhook.1.url", url);
@@ -418,7 +418,7 @@ public class WebHookTest{
 
 	@Ignore
 	public void test_WebHookCollectionWithNonExistantRecursiveParameterReference(){
-		Map <String, String> params = new HashMap<String, String>();
+		Map <String, String> params = new HashMap<>();
 		params.put("system.test.recursive1", "%system.test.recursive3%");
 		params.put("system.test.recursive2", "blahblah");
 		params.put("system.webhook.1.url", url);
@@ -437,7 +437,7 @@ public class WebHookTest{
 	
 	@Ignore
 	public void test_WebHookCollectionWithPost() throws WebHookParameterReferenceException, InterruptedException {
-		Map <String, String> params = new HashMap<String, String>();
+		Map <String, String> params = new HashMap<>();
 		//params.put("system.webhook.1.url", url + "/200");
 		params.put("system.webhook.1.url", "http://localhost/webhook/" );
 		params.put("system.webhook.1.enabled", "true");

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/MockSProject.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/MockSProject.java
@@ -52,9 +52,9 @@ public class MockSProject implements SProject {
 	private Status status;
 	private SBuildType buildType;
 	private SProject parentProject;
-	private Map<String,SBuildType> buildTypes = new HashMap<String, SBuildType>();
-	private List<SProject> parentPath = new ArrayList<SProject>();
-	private List<SProject> childProjects = new ArrayList<SProject>();
+	private Map<String,SBuildType> buildTypes = new HashMap<>();
+	private List<SProject> parentPath = new ArrayList<>();
+	private List<SProject> childProjects = new ArrayList<>();
 
 	public MockSProject(String name, String description, String projectId, String projectExternalId, 
 						SBuildType buildType)
@@ -112,7 +112,7 @@ public class MockSProject implements SProject {
 	}
 
 	public List<SBuildType> getBuildTypes() {
-		return new ArrayList<SBuildType>(this.buildTypes.values());
+		return new ArrayList<>(this.buildTypes.values());
 	}
 
 	public File getConfigDirectory() {

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/MockSRunningBuild.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/MockSRunningBuild.java
@@ -70,7 +70,7 @@ public class MockSRunningBuild implements SRunningBuild {
 	private Status status;
 	private String statusText;
 	private long buildId = 123456;
-	private Map<String,String> buildParameters = new TreeMap<String, String>();
+	private Map<String,String> buildParameters = new TreeMap<>();
 	private ParametersProvider parameterProvider;
 	private List<SVcsModification> modifications;
 

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/WebHookContentBuilderTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/WebHookContentBuilderTest.java
@@ -28,8 +28,8 @@ public class WebHookContentBuilderTest {
 	
 	SFinishedBuild previousSuccessfulBuild = mock(SFinishedBuild.class);
 	SFinishedBuild previousFailedBuild = mock(SFinishedBuild.class);
-	List<SFinishedBuild> finishedSuccessfulBuilds = new ArrayList<SFinishedBuild>();
-	List<SFinishedBuild> finishedFailedBuilds = new ArrayList<SFinishedBuild>();
+	List<SFinishedBuild> finishedSuccessfulBuilds = new ArrayList<>();
+	List<SFinishedBuild> finishedFailedBuilds = new ArrayList<>();
 	MockSBuildType sBuildType = new MockSBuildType("Test Build", "A Test Build", "bt1");
 	MockSRunningBuild sRunningBuild = new MockSRunningBuild(sBuildType, "SubVersion", Status.NORMAL, "Running", "TestBuild01");
 	MockSProject sProject = new MockSProject("Test Project", "A test project", "project1", "ATestProject", sBuildType);

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/WebHookListenerTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/WebHookListenerTest.java
@@ -61,8 +61,8 @@ public class WebHookListenerTest {
 	WebHookConfig webHookConfig;
 	SFinishedBuild previousSuccessfulBuild = mock(SFinishedBuild.class);
 	SFinishedBuild previousFailedBuild = mock(SFinishedBuild.class);
-	List<SFinishedBuild> finishedSuccessfulBuilds = new ArrayList<SFinishedBuild>();
-	List<SFinishedBuild> finishedFailedBuilds = new ArrayList<SFinishedBuild>();
+	List<SFinishedBuild> finishedSuccessfulBuilds = new ArrayList<>();
+	List<SFinishedBuild> finishedFailedBuilds = new ArrayList<>();
 	MockSBuildType sBuildType = new MockSBuildType("Test Build", "A Test Build", "bt1");
 	MockSRunningBuild sRunningBuild = new MockSRunningBuild(sBuildType, "SubVersion", Status.NORMAL, "Running", "TestBuild01");
 	MockSProject sProject = new MockSProject("Test Project", "A test project", "project1", "ATestProject", sBuildType);

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/WebHookPayloadTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/WebHookPayloadTest.java
@@ -44,7 +44,7 @@ public class WebHookPayloadTest {
 		WebHookPayloadManager wpm = new WebHookPayloadManager(mockServer);
 		WebHookPayloadNameValuePairs whp = new WebHookPayloadNameValuePairs(wpm);
 		whp.register();
-		SortedMap<String, String> extraParameters = new TreeMap<String, String>();
+		SortedMap<String, String> extraParameters = new TreeMap<>();
 		extraParameters.put("something", "somewhere");
 		//String content = wpm.getFormat("nvpairs").buildStarted(sRunningBuild, extraParameters);
 		System.out.println(sRunningBuild.getBuildDescription());

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/auth/UserPassAuthWithRealServerTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/auth/UserPassAuthWithRealServerTest.java
@@ -20,7 +20,7 @@ import webhook.testframework.WebHookMockingFrameworkImpl;
 
 public class UserPassAuthWithRealServerTest {
 
-	SortedMap<String, String> map = new TreeMap<String, String>();
+	SortedMap<String, String> map = new TreeMap<>();
 	ExtraParametersMap  extraParameters  = new ExtraParametersMap(map); 
 	ExtraParametersMap  teamcityProperties  = new ExtraParametersMap(map); 
 	WebHookMockingFramework framework;

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/payload/content/WebHookPayloadContentTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/payload/content/WebHookPayloadContentTest.java
@@ -17,7 +17,7 @@ import webhook.testframework.WebHookMockingFrameworkImpl;
 
 public class WebHookPayloadContentTest {
 	
-	SortedMap<String, String> map = new TreeMap<String, String>();
+	SortedMap<String, String> map = new TreeMap<>();
 	ExtraParametersMap  extraParameters  = new ExtraParametersMap(map); 
 	ExtraParametersMap  teamcityProperties  = new ExtraParametersMap(map); 
 	WebHookMockingFramework framework;

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/payload/format/WebHookPayloadTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/payload/format/WebHookPayloadTest.java
@@ -38,7 +38,7 @@ public class WebHookPayloadTest {
 		WebHookPayloadManager wpm = new WebHookPayloadManager(mockServer);
 		WebHookPayloadXml whp = new WebHookPayloadXml(wpm);
 		whp.register();
-		SortedMap<String, String> extraParameters = new TreeMap<String, String>();
+		SortedMap<String, String> extraParameters = new TreeMap<>();
 		
 		extraParameters.put("item1", "content1");
 		extraParameters.put("item2", "content2");
@@ -68,7 +68,7 @@ public class WebHookPayloadTest {
 		WebHookPayloadManager wpm = new WebHookPayloadManager(mockServer);
 		WebHookPayloadJson whp = new WebHookPayloadJson(wpm);
 		whp.register();
-		SortedMap<String, String> extraParameters = new TreeMap<String, String>();
+		SortedMap<String, String> extraParameters = new TreeMap<>();
 		
 		extraParameters.put("item1", "content1");
 		extraParameters.put("item2", "content2");
@@ -97,7 +97,7 @@ public class WebHookPayloadTest {
 		WebHookPayloadManager wpm = new WebHookPayloadManager(mockServer);
 		WebHookPayloadNameValuePairs whp = new WebHookPayloadNameValuePairs(wpm);
 		whp.register();
-		SortedMap<String, String> extraParameters = new TreeMap<String, String>();
+		SortedMap<String, String> extraParameters = new TreeMap<>();
 		
 		extraParameters.put("item1", "content1");
 		extraParameters.put("item2", "content2");
@@ -125,7 +125,7 @@ public class WebHookPayloadTest {
 		WebHookPayloadManager wpm = new WebHookPayloadManager(mockServer);
 		WebHookPayloadEmpty whp = new WebHookPayloadEmpty(wpm);
 		whp.register();
-		SortedMap<String, String> extraParameters = new TreeMap<String, String>();
+		SortedMap<String, String> extraParameters = new TreeMap<>();
 		
 		extraParameters.put("item1", "content1");
 		extraParameters.put("item2", "content2");

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/payload/template/ElasticSearchWebHookTemplateTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/payload/template/ElasticSearchWebHookTemplateTest.java
@@ -67,7 +67,7 @@ public class ElasticSearchWebHookTemplateTest {
 		MockSRunningBuild sRunningBuild = new MockSRunningBuild(sBuildType, triggeredBy, Status.NORMAL, "Running", "TestBuild01");
 		SFinishedBuild previousBuild = mock(SFinishedBuild.class);
 		when (previousBuild.getFinishDate()).thenReturn(new Date());
-		List<SFinishedBuild> finishedBuilds = new ArrayList<SFinishedBuild>();
+		List<SFinishedBuild> finishedBuilds = new ArrayList<>();
 		finishedBuilds.add(previousBuild);
 		BuildHistory buildHistory = mock(BuildHistory.class);
 		when(buildHistory.getEntriesBefore(sRunningBuild, false)).thenReturn(finishedBuilds);

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/payload/template/JsonTemplateRenderingTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/payload/template/JsonTemplateRenderingTest.java
@@ -50,7 +50,7 @@ public class JsonTemplateRenderingTest {
 		WebHookPayloadManager wpm = new WebHookPayloadManager(mockServer);
 		WebHookPayloadJsonTemplate whp = new WebHookPayloadJsonTemplate(wpm);
 		whp.register();
-		SortedMap<String, String> extraParameters = new TreeMap<String, String>();
+		SortedMap<String, String> extraParameters = new TreeMap<>();
 		
 		extraParameters.put("item1", "content1");
 		extraParameters.put("item2", "content2");

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/payload/template/WebHookTemplateManagerTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/payload/template/WebHookTemplateManagerTest.java
@@ -155,12 +155,12 @@ public class WebHookTemplateManagerTest {
 
 		@Override
 		public Set<BuildStateEnum> getSupportedBuildStates() {
-			return new HashSet<BuildStateEnum>(Arrays.asList(BuildStateEnum.BUILD_SUCCESSFUL));
+			return new HashSet<>(Arrays.asList(BuildStateEnum.BUILD_SUCCESSFUL));
 		}
 
 		@Override
 		public Set<BuildStateEnum> getSupportedBranchBuildStates() {
-			return new HashSet<BuildStateEnum>(Arrays.asList(BuildStateEnum.BUILD_SUCCESSFUL));
+			return new HashSet<>(Arrays.asList(BuildStateEnum.BUILD_SUCCESSFUL));
 		}
 
 		@Override

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/payload/util/VariableMessageBuilderTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/payload/util/VariableMessageBuilderTest.java
@@ -38,13 +38,13 @@ public class VariableMessageBuilderTest {
 	@Before
 	public void setup(){
 		sBuildType.setProject(sProject);
-		extraParameters = new TreeMap<String, String>();
+		extraParameters = new TreeMap<>();
 		//extraParameters.put("build.vcs.number", "${build.vcs.number}");
 		extraParameters.put("body.passed", "Yey, this build has passed for ${buildType}.");
 		extraParameters.put("body", "${body.passed}");
 		extraParameters.put("body2", "${body.failed}");
 		extraParameters.put("sha", "${build.vcs.number}");
-		teamcityProperties = new TreeMap<String, String>();
+		teamcityProperties = new TreeMap<>();
 		teamcityProperties.put("env.isInATest", "Yes, we are in a test");
 		teamcityProperties.put("buildFullName", "Hopefully will never see this.");
 		teamcityProperties.put("buildFullName", "Hopefully will never see this.");
@@ -54,7 +54,7 @@ public class VariableMessageBuilderTest {
 		teamcityProperties.put("config", "This is some config thing");
 		teamcityProperties.put("builder.appVersion", "This is the appVersion");
 		sBuildServer = mock(SBuildServer.class);
-		allProperties = new LinkedHashMap<String, ExtraParametersMap>();
+		allProperties = new LinkedHashMap<>();
 		allProperties.put("teamcity", new ExtraParametersMap(teamcityProperties));
 		allProperties.put("webhook", new ExtraParametersMap(extraParameters));
 	}

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/settings/WebHookSettingsTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/settings/WebHookSettingsTest.java
@@ -187,7 +187,7 @@ public class WebHookSettingsTest {
 	@Test
 	public void test_WebookConfig() throws JDOMException, IOException{
 		SAXBuilder builder = new SAXBuilder();
-		List<WebHookConfig> configs = new ArrayList<WebHookConfig>();
+		List<WebHookConfig> configs = new ArrayList<>();
 		builder.setIgnoringElementContentWhitespace(true);
 			Document doc = builder.build("src/test/resources/testdoc2.xml");
 			Element root = doc.getRootElement();

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/settings/entity/WebHookTemplateJaxHelperTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/settings/entity/WebHookTemplateJaxHelperTest.java
@@ -83,7 +83,7 @@ public class WebHookTemplateJaxHelperTest {
 
 	@Test
 	public void testLoad() {
-		Map<String, WebHookTemplateFromXml> templatesMap = new HashMap<String, WebHookTemplateFromXml>(); 
+		Map<String, WebHookTemplateFromXml> templatesMap = new HashMap<>();
 		WebHookTemplates templatesList =  WebHookTemplateJaxHelper.load("src/test/resources/webhook-templates.xml", templatesMap);
 	}
 

--- a/tcwebhooks-core/src/test/java/webhook/testframework/WebHookMockingFrameworkImpl.java
+++ b/tcwebhooks-core/src/test/java/webhook/testframework/WebHookMockingFrameworkImpl.java
@@ -84,9 +84,9 @@ public class WebHookMockingFrameworkImpl implements WebHookMockingFramework {
 	WebHook spyWebHook;
 	SFinishedBuild previousSuccessfulBuild = mock(SFinishedBuild.class);
 	SFinishedBuild previousFailedBuild = mock(SFinishedBuild.class);
-	List<SFinishedBuild> finishedSuccessfulBuilds = new ArrayList<SFinishedBuild>();
-	List<SFinishedBuild> finishedFailedBuilds = new ArrayList<SFinishedBuild>();
-	List<SFinishedBuild> finishedBuildsHistory = new ArrayList<SFinishedBuild>();
+	List<SFinishedBuild> finishedSuccessfulBuilds = new ArrayList<>();
+	List<SFinishedBuild> finishedFailedBuilds = new ArrayList<>();
+	List<SFinishedBuild> finishedBuildsHistory = new ArrayList<>();
 	
 	SBuildType sBuildType = new MockSBuildType("Test Build", "A Test Build", "bt1");
 	SBuildType sBuildType02 = new MockSBuildType("Test Build-2", "A Test Build 02", "bt2");
@@ -105,8 +105,8 @@ public class WebHookMockingFrameworkImpl implements WebHookMockingFramework {
 	SortedMap<String, String> extraParameters;
 	SortedMap<String, String> teamcityProperties;
 	BuildStateEnum buildstateEnum;
-	List<WebHookTemplate> templateList = new ArrayList<WebHookTemplate>();
-	List<WebHookPayload> formatList = new ArrayList<WebHookPayload>();
+	List<WebHookTemplate> templateList = new ArrayList<>();
+	List<WebHookPayload> formatList = new ArrayList<>();
 	
 	private WebHookMockingFrameworkImpl() {
 		webHookImpl = new WebHookImpl();
@@ -228,7 +228,7 @@ public class WebHookMockingFrameworkImpl implements WebHookMockingFramework {
 			
 			@Override
 			public Set<BuildStateEnum> getSupportedBuildStates() {
-				Set<BuildStateEnum> states = new HashSet<BuildStateEnum>();
+				Set<BuildStateEnum> states = new HashSet<>();
 				for (BuildStateEnum state: supportedStates){
 					states.add(state);
 				}
@@ -237,7 +237,7 @@ public class WebHookMockingFrameworkImpl implements WebHookMockingFramework {
 			
 			@Override
 			public Set<BuildStateEnum> getSupportedBranchBuildStates() {
-				Set<BuildStateEnum> states = new HashSet<BuildStateEnum>();
+				Set<BuildStateEnum> states = new HashSet<>();
 				for (BuildStateEnum state: supportedStates){
 					states.add(state);
 				}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.
Soso Tughushi