### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/tcwebhooks-core/src/main/java/webhook/teamcity/Loggers.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/Loggers.java
@@ -3,6 +3,8 @@ package webhook.teamcity;
 import com.intellij.openapi.diagnostic.Logger;
 
 public final class Loggers {
+	private Loggers(){}
+
 	public static final Logger SERVER 		= Logger.getInstance("jetbrains.buildServer.SERVER");
 	public static final Logger ACTIVITIES  	= Logger.getInstance("jetbrains.buildServer.ACTIVITIES");
 }

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/TeamCityIdResolver.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/TeamCityIdResolver.java
@@ -8,6 +8,8 @@ import jetbrains.buildServer.serverSide.SBuildType;
 import jetbrains.buildServer.serverSide.SProject;
 
 public final class TeamCityIdResolver {
+
+	private TeamCityIdResolver(){}
 	
 	public static String getBuildTypeId(SBuildType buildType){
 		try {

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookPayloadDefaultTemplates.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookPayloadDefaultTemplates.java
@@ -4,6 +4,8 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class WebHookPayloadDefaultTemplates {
+
+	private WebHookPayloadDefaultTemplates(){}
 	
 	public static final String HTML_BUILDSTATUS_TEMPLATE = "buildStatusHtml";
 	public static final String TEXT_TEMPLATE = "text";

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHooksChangeBuilder.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHooksChangeBuilder.java
@@ -6,6 +6,7 @@ import java.util.List;
 import jetbrains.buildServer.vcs.SVcsModification;
 
 public class WebHooksChangeBuilder{
+	private WebHooksChangeBuilder(){}
 	
 	public static List<WebHooksChanges> build (List<SVcsModification> mods){
 		List<WebHooksChanges> changes = new ArrayList<WebHooksChanges>();

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/util/StringSanitiser.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/util/StringSanitiser.java
@@ -2,6 +2,8 @@ package webhook.teamcity.payload.util;
 
 public class StringSanitiser {
 
+	private StringSanitiser(){}
+
 	public static String sanitise(String dirtyString) {
 		return dirtyString
 				.replace("<", "_")

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/converter/OldStyleBuildState.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/converter/OldStyleBuildState.java
@@ -1,6 +1,9 @@
 package webhook.teamcity.settings.converter;
 
 public final class OldStyleBuildState {
+
+	private OldStyleBuildState(){}
+
     public static final Integer BUILD_STARTED  			= Integer.parseInt("00000001",2);
     public static final Integer BUILD_FINISHED 			= Integer.parseInt("00000010",2);
     public static final Integer BUILD_CHANGED_STATUS 	= Integer.parseInt("00000100",2);

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/converter/WebHookBuildStateConverter.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/converter/WebHookBuildStateConverter.java
@@ -5,6 +5,8 @@ import webhook.teamcity.BuildStateEnum;
 
 public class WebHookBuildStateConverter {
 
+	private WebHookBuildStateConverter(){}
+
 	public static BuildState convert(Integer oldState){
 		BuildState newStates = new BuildState();
 		

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/entity/WebHookTemplateJaxHelper.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/entity/WebHookTemplateJaxHelper.java
@@ -20,6 +20,8 @@ import webhook.teamcity.payload.template.WebHookTemplateFromXml;
 
 public class WebHookTemplateJaxHelper {
 
+	private WebHookTemplateJaxHelper(){}
+
 	/**
 	 * Read saved configuration from file
 	 * 

--- a/tcwebhooks-core/src/test/java/webhook/testframework/util/ConfigLoaderUtil.java
+++ b/tcwebhooks-core/src/test/java/webhook/testframework/util/ConfigLoaderUtil.java
@@ -13,6 +13,7 @@ import org.jdom.input.SAXBuilder;
 import webhook.teamcity.settings.WebHookConfig;
 
 public class ConfigLoaderUtil {
+	private ConfigLoaderUtil(){}
 	
 	public static Element getFullConfigElement(File file) throws JDOMException, IOException{
 		SAXBuilder builder = new SAXBuilder();

--- a/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/ProjectWebHooksBeanJsonSerialiser.java
+++ b/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/ProjectWebHooksBeanJsonSerialiser.java
@@ -7,6 +7,7 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.json.JsonHierarchicalStreamDriver;
 
 public class ProjectWebHooksBeanJsonSerialiser {
+    private ProjectWebHooksBeanJsonSerialiser(){}
 	
 	public static String serialise(TemplatesAndProjectWebHooksBean project){
 		XStream xstream = new XStream(new JsonHierarchicalStreamDriver());

--- a/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/template/RegisteredWebHookTemplateBeanJsonSerialiser.java
+++ b/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/template/RegisteredWebHookTemplateBeanJsonSerialiser.java
@@ -4,6 +4,8 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.json.JsonHierarchicalStreamDriver;
 
 public class RegisteredWebHookTemplateBeanJsonSerialiser {
+
+	private RegisteredWebHookTemplateBeanJsonSerialiser(){}
 	
 	public static String serialise(RegisteredWebHookTemplateBean templates){
 		XStream xstream = new XStream(new JsonHierarchicalStreamDriver());

--- a/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/template/TemplateRenderingBeanJsonSerialiser.java
+++ b/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/template/TemplateRenderingBeanJsonSerialiser.java
@@ -6,6 +6,7 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.io.json.JsonHierarchicalStreamDriver;
 
 public class TemplateRenderingBeanJsonSerialiser {
+	private TemplateRenderingBeanJsonSerialiser(){}
 	
 	public static String serialise(TemplateRenderingBean templateRendering){
 		XStream xstream = new XStream(new JsonHierarchicalStreamDriver());

--- a/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/util/ProjectHistoryResolver.java
+++ b/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/util/ProjectHistoryResolver.java
@@ -11,6 +11,7 @@ import jetbrains.buildServer.serverSide.SFinishedBuild;
 import jetbrains.buildServer.serverSide.SProject;
 
 public class ProjectHistoryResolver {
+	private ProjectHistoryResolver(){}
 	
 	private static final int MAX_BUILDS_PER_BUILD_TYPE = 5;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.
Soso TUghushi