### PR TITLE
Bugfix/137 fix break on project names

### DIFF
--- a/tcwebhooks-rest-api/src/main/resources/buildServerResources/WebHookRestApi/restApiHealthStatus.js
+++ b/tcwebhooks-rest-api/src/main/resources/buildServerResources/WebHookRestApi/restApiHealthStatus.js
@@ -13,7 +13,7 @@ WebHookRestApiHealthStatus = {
     	
     	showDialog: function (title, action, filePath) {
     		$j("#fixPluginForm input[id='FixPluginaction']").val(action);
-    		$j("#fixPluginDialog .dialogTitle").html(title);
+    		$j("#fixPluginDialog .dialogTitle").text(title);
     		this.cleanFields(filePath);
     		this.cleanErrors();
     		this.showCentered();

--- a/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/index.jsp
+++ b/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/index.jsp
@@ -176,7 +176,7 @@
 		   			locator = '';
 		   		}
 		   		
-	    		jQueryWebhook("#currentTemplateBuildId").empty().append(jQueryWebhook('<option></option>').val(null).html("Loading build history..."))
+	    		jQueryWebhook("#currentTemplateBuildId").empty().append(jQueryWebhook('<option></option>').val(null).text("Loading build history..."))
 	    		jQueryWebhook.ajax ({
 	    			url: window['base_uri'] + '/app/rest/builds?locator=' + locator 
 	    					+ "state:finished&fields=build(id,number,status,finishDate,buildType(id,name))",
@@ -186,7 +186,7 @@
 	    			},
 	    			success: function (response) {
 	    				var myselect = jQueryWebhook('<select>');
-	    				myselect.append( jQueryWebhook('<option></option>').val(null).html("Choose a Build...") );
+	    				myselect.append( jQueryWebhook('<option></option>').val(null).text("Choose a Build...") );
 	    				jQueryWebhook(response.build).each(function(index, build) {
 	    					console.log(build);
 	    					var desc = build.buildType.name 
@@ -195,14 +195,14 @@
 	    							  + moment(build.finishDate, moment.ISO_8601).fromNow()
 	    							  + ")";
 	    					console.log(desc);
-							myselect.append( jQueryWebhook('<option></option>').val(build.id).html(desc) );
+							myselect.append( jQueryWebhook('<option></option>').val(build.id).text(desc) );
 	    				});
-	    				jQueryWebhook("#currentTemplateBuildId").empty().append(myselect.html());
+	    				jQueryWebhook("#currentTemplateBuildId").empty().append(myselect);
 	    			},
 	    			error: function (response) {
 	    				if (response.status == 404) {
 	    					jQueryWebhook("#currentTemplateBuildId").empty().append(
-	    							jQueryWebhook('<option></option>').val(null).html("No builds found. Choose a different project")
+	    							jQueryWebhook('<option></option>').val(null).text("No builds found. Choose a different project.")
 	    						);
 	    				} else {
 		    				console.log(response);
@@ -245,15 +245,15 @@
 		function updateSelectedBuildTypes(){
 			var subText = "";
 		    if(jQueryWebhook('#buildTypeSubProjects').is(':checked')){
-		    	subText = " &amp; sub-projects";
+		    	subText = " & sub-projects";
 		    }
 		
 			if(jQueryWebhook('#webHookFormContents input.buildType_single:checked').length == jQueryWebhook('#webHookFormContents input.buildType_single').length){
 				jQueryWebhook('input.buildType_all').prop('checked', true);
-				jQueryWebhook('span#selectedBuildCount').html("all" + subText);
+				jQueryWebhook('span#selectedBuildCount').text("all" + subText);
 			} else {
 				jQueryWebhook('input.buildType_all').prop('checked', false);
-				jQueryWebhook('span#selectedBuildCount').html(jQueryWebhook('#webHookFormContents input.buildType_single:checked').length + subText);
+				jQueryWebhook('span#selectedBuildCount').text(jQueryWebhook('#webHookFormContents input.buildType_single:checked').length + subText);
 			}
 
 		}
@@ -423,15 +423,6 @@
 			return name;
 		}
 		
-		function htmlEscape(str) {
-    		return String(str)
-            .replace(/&/g, '&amp;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;');
-		}
-		
 		function addWebHooksFromJsonCallback(){
 			var webhookItems = ProjectBuilds.templatesAndWebhooks.projectWebhookConfig.webHookList;
 			jQueryWebhook.each(webhookItems, function(webHookKey, webhook){
@@ -442,12 +433,13 @@
 									.removeClass('webHookRowTemplate')
 									.addClass('webHookRow')
 									.appendTo('#webHookTable > tbody');
-					jQueryWebhook("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemUrl").html(htmlEscape(webhook.url)).click(function(){BS.EditWebHookDialog.showDialog(webhook.uniqueKey, '#hookPane');});
+					jQueryWebhook("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemUrl").text(webhook.url).click(function(){BS.EditWebHookDialog.showDialog(webhook.uniqueKey, '#hookPane');});
 					if (webhook.payloadTemplate === 'none') {
-						jQueryWebhook("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemFormat").html(webhook.payloadFormatForWeb);
+						jQueryWebhook("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemFormat").text(webhook.payloadFormatForWeb);
 					} else {
-						jQueryWebhook("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemFormat").html("<a href='template.html?template=" + webhook.payloadTemplate +"'>" + webhook.payloadFormatForWeb + "</a>");
+						jQueryWebhook("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemFormat").html("").append($j("<a href='template.html?template=" + webhook.payloadTemplate +"'></a>").text(webhook.payloadFormatForWeb));
 					}
+					// Note: Assuming these .*ForWeb members are clean/safe
 					jQueryWebhook("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemEvents").html(webhook.enabledEventsListForWeb).click(function(){BS.EditWebHookDialog.showDialog(webhook.uniqueKey,'#hookPane');});
 					jQueryWebhook("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemBuilds").html(webhook.enabledBuildsListForWeb).click(function(){BS.EditWebHookDialog.showDialog(webhook.uniqueKey, '#buildPane');});
 					jQueryWebhook("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemEdit > a").click(function(){BS.EditWebHookDialog.showDialog(webhook.uniqueKey,'#hookPane');});

--- a/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/js/addWebhookTemplate.js
+++ b/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/js/addWebhookTemplate.js
@@ -29,7 +29,7 @@ WebHooksPlugin = {
     	
     	showDialog: function (title, action, data) {
     		$j("input[id='WebhookTemplateaction']").val(action);
-    		$j(".dialogTitle").html(title);
+    		$j(".dialogTitle").text(title);
     		$j("#addTemplateForm #addTemplateDialogSubmit").hide();
     		$j("#addTemplateForm #addTemplateDialogExpand").show();
     		$j("#addTemplateForm .templateDetails").hide();

--- a/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/js/editWebhook.js
+++ b/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/js/editWebhook.js
@@ -290,14 +290,14 @@ WebHooksPlugin = {
 							var ul = $j('<ul>');
 							
 							if (response.error) {
-								ul.append($j('<li/>').html("Error: " + htmlEscape(response.error.message) + " (" + response.error.errorCode + ")"));
+								ul.append($j('<li/>').text("Error: " + response.error.message + " (" + response.error.errorCode + ")"));
 							} else {
-								ul.append($j('<li/>').html("Success: " + htmlEscape(response.statusReason) + " (" + response.statusCode + ")"));
+								ul.append($j('<li/>').text("Success: " + response.statusReason + " (" + response.statusCode + ")"));
 							}
-							ul.append($j('<li/>').html("URL: " + htmlEscape(response.url)));
-							ul.append($j('<li/>').html("Duration: " + response.executionTime + " @ " + moment(response.dateTime, moment.ISO_8601).format("dddd, MMMM Do YYYY, h:mm:ss a")));
+							ul.append($j('<li/>').text("URL: " + response.url));
+							ul.append($j('<li/>').text("Duration: " + response.executionTime + " @ " + moment(response.dateTime, moment.ISO_8601).format("dddd, MMMM Do YYYY, h:mm:ss a")));
 							
-							$j("#webhookDialogAjaxResult").empty().append(ul.html());
+							$j("#webhookDialogAjaxResult").empty().append(ul);
 							console.log(response);
 						},
 						error: function (response) {
@@ -329,7 +329,7 @@ function populateBuildHistoryAjax(locator) {
    			locator = '';
    		}
    		
-		$j("#webhookPreviewBuildId").empty().append($j('<option></option>').val(null).html("Loading build history..."))
+		$j("#webhookPreviewBuildId").empty().append($j('<option></option>').val(null).text("Loading build history..."))
 		$j.ajax ({
 			url: window['base_uri'] + '/app/rest/builds?locator=' + locator 
 					+ "state:finished&fields=build(id,number,status,finishDate,buildType(id,name))",
@@ -339,23 +339,23 @@ function populateBuildHistoryAjax(locator) {
 			},
 			success: function (response) {
 				var myselect = $j('<select>');
-				myselect.append( $j('<option></option>').val(null).html("Choose a Build...") );
+				myselect.append( $j('<option></option>').val(null).text("Choose a Build...") );
 				$j(response.build).each(function(index, build) {
 					//console.log(build);
-					var desc = htmlEscape(build.buildType.name) 
-							  + "#" + build.number 
+					var desc = build.buildType.name
+							  + "#" + build.number
 							  + " - " + build.status + " ("
 							  + moment(build.finishDate, moment.ISO_8601).fromNow()
 							  + ")";
 					//console.log(desc);
-					myselect.append( $j('<option></option>').val(build.id).html(desc) );
+					myselect.append( $j('<option></option>').val(build.id).text(desc) );
 				});
-				$j("#webhookPreviewBuildId").empty().append(myselect.html());
+				$j("#webhookPreviewBuildId").empty().append(myselect);
 			},
 			error: function (response) {
 				if (response.status == 404) {
 					$j("#webhookPreviewBuildId").empty().append(
-							$j('<option></option>').val(null).html("No builds found. Choose a different project")
+							$j('<option></option>').val(null).text("No builds found. Choose a different project.")
 						);
 				} else {
     				console.log(response);
@@ -398,15 +398,15 @@ function toggleAllBuildTypesSelected(){
 function updateSelectedBuildTypes(){
 	var subText = "";
     if($j('#buildTypeSubProjects').is(':checked')){
-    	subText = " &amp; sub-projects";
+    	subText = " & sub-projects";
     }
 
 	if($j('#webHookFormContents input.buildType_single:checked').length == $j('#webHookFormContents input.buildType_single').length){
 		$j('input.buildType_all').prop('checked', true);
-		$j('span#selectedBuildCount').html("all" + subText);
+		$j('span#selectedBuildCount').text("all" + subText);
 	} else {
 		$j('input.buildType_all').prop('checked', false);
-		$j('span#selectedBuildCount').html($j('#webHookFormContents input.buildType_single:checked').length + subText);
+		$j('span#selectedBuildCount').text($j('#webHookFormContents input.buildType_single:checked').length + subText);
 	}
 
 }
@@ -539,11 +539,15 @@ function populateWebHookDialog(id){
 			$j.each(webhook.builds, function(){
 				var thing = $j(this.buildTypeName).text();
 				console.log(thing);
-				 if (this.enabled){
-			 	 	$j('#buildList').append('<p style="border-bottom:solid 1px #cccccc; margin:0; padding:0.5em;"><label><input checked onclick="updateSelectedBuildTypes();" type=checkbox style="padding-right: 1em;" name="buildTypeId" value="' + this.buildTypeId + '"class="buildType_single">' + htmlEscape(this.buildTypeName) + '</label></p>');
-				 } else {
-				 	 $j('#buildList').append('<p style="border-bottom:solid 1px #cccccc; margin:0; padding:0.5em;"><label><input onclick="updateSelectedBuildTypes();" type=checkbox style="padding-right: 1em;" name="buildTypeId" value="' + this.buildTypeId + '"class="buildType_single">' + htmlEscape(this.buildTypeName) + '</label></p>');
-				 }
+				var isChecked = '';
+				if (this.enabled) {
+					isChecked = ' checked';
+				}
+				var label = $j('<label><input' + isChecked + ' onclick="updateSelectedBuildTypes();" type=checkbox style="padding-right: 1em;" name="buildTypeId" value="' + this.buildTypeId + '"class="buildType_single"></label>');
+				label.text(this.buildTypeName);
+				var container = $j('<p style="border-bottom:solid 1px #cccccc; margin:0; padding:0.5em;"></p>');
+				container.append(label);
+				$j('#buildList').append(container);
 			});
 			
 			populateWebHookAuthExtrasPane(webhook);
@@ -551,7 +555,7 @@ function populateWebHookDialog(id){
 				populateWebHookAuthExtrasPaneFromChange(webhook);
 			});
 			if ($j('#payloadFormatHolder').val()) {
-				$j('#currentTemplateName').html(htmlEscape(lookupTemplateName($j('#payloadFormatHolder').val())));
+				$j('#currentTemplateName').text(lookupTemplateName($j('#payloadFormatHolder').val()));
 			} else {
 				$j('#currentTemplateName').html("&nbsp;");
 			}
@@ -623,15 +627,6 @@ function lookupAuthParameters(authTypeValue, webHookForm) {
 	return authParams;
 }
 
-function htmlEscape(str) {
-	return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
-
 function addWebHooksFromJsonCallback(){
 	var webhookItems = ProjectBuilds.templatesAndWebhooks.projectWebhookConfig.webHookList;
 	$j.each(webhookItems, function(webHookKey, webhook){
@@ -652,11 +647,11 @@ function addWebHooksFromJsonCallback(){
 			}
 			newRow.appendTo('#webHookTable > tbody');
 			
-			$j("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemUrl").html(htmlEscape(webhook.url)).click(function(){WebHooksPlugin.showEditDialog(webhook.uniqueKey, '#hookPane');});
+			$j("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemUrl").text(webhook.url).click(function(){WebHooksPlugin.showEditDialog(webhook.uniqueKey, '#hookPane');});
 			if (webhook.payloadTemplate === 'none') {
-				$j("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemFormat").html(htmlEscape(webhook.payloadFormatForWeb));
+				$j("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemFormat").text(webhook.payloadFormatForWeb);
 			} else {
-				$j("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemFormat").html("<a href='template.html?template=" + webhook.payloadTemplate +"'>" + htmlEscape(webhook.payloadFormatForWeb) + "</a>");
+				$j("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemFormat").html("").append($j("<a href='template.html?template=" + webhook.payloadTemplate +"'></a>").text(webhook.payloadFormatForWeb));
 			}
 			$j("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemEvents").html(webhook.enabledEventsListForWeb).click(function(){WebHooksPlugin.showEditDialog(webhook.uniqueKey,'#hookPane');});
 			$j("#viewRow_" + webhook.uniqueKey + " > td.webHookRowItemBuilds").html(webhook.enabledBuildsListForWeb).click(function(){WebHooksPlugin.showEditDialog(webhook.uniqueKey, '#buildPane');});

--- a/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/js/editWebhook.js
+++ b/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/js/editWebhook.js
@@ -33,7 +33,7 @@ WebHooksPlugin = {
     	showDialog: function (title, action, id) {
     		$j("#editWebHookForm input[id='webHookId']").val("none"); // Unset the edit id, so that it doesn't get animated by delete.
     		$j("input[id='webHookaction']").val(action);
-    		$j(".dialogTitle").html(title);
+    		$j(".dialogTitle").text(title);
     		this.cleanFields(id);
     		this.cleanErrors();
     		this.showCentered();
@@ -139,7 +139,7 @@ WebHooksPlugin = {
         showDialog: function (title, action, id, tab) {
         	
         	this.formElement().submitAction.value = action;
-            $j(".dialogTitle").html(title);
+            $j(".dialogTitle").text(title);
             this.cleanFields(id);
             this.cleanErrors();
             

--- a/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/js/editWebhook.js
+++ b/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/js/editWebhook.js
@@ -536,9 +536,8 @@ function populateWebHookDialog(id){
 			$j('#webHookFormContents select#payloadFormatHolder').val(webhook.payloadTemplate + "_" + webhook.payloadFormat).change();
 			
 			$j('#buildTypeSubProjects').prop('checked', webhook.subProjectsEnabled);
-			$j.each(webhook.builds, function(){
-				var thing = $j(this.buildTypeName).text();
-				console.log(thing);
+			$j.each(webhook.builds, function() {
+				console.log('Adding subproject', this.buildTypeId, 'named', this.buildTypeName);
 				var isChecked = '';
 				if (this.enabled) {
 					isChecked = ' checked';

--- a/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/js/editWebhookTemplate.js
+++ b/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/js/editWebhookTemplate.js
@@ -312,7 +312,7 @@ WebHooksPlugin = {
 			});
 		}, 
 		handleGetSuccess: function (action) {
-			$j("#templateHeading").html(htmlEscape(myJson.parentTemplate.description));
+			$j("#templateHeading").text(myJson.parentTemplate.description);
 			// If we have the pluralised name, pass the reference to a singular form.
 			// This works around Jackson 2.x using singular names, and Jackson 1.x using plural.
 			if (typeof myJson.parentTemplate.templateItems !== 'undefined' 
@@ -379,7 +379,7 @@ WebHooksPlugin = {
 			});
 		}, 
 		handlePutSuccess: function () {
-			$j("#templateHeading").html(htmlEscape(myJson.parentTemplateDescription));
+			$j("#templateHeading").text(myJson.parentTemplateDescription);
 			this.updateCheckboxes();
 			this.updateEditor();
 		},
@@ -464,7 +464,7 @@ WebHooksPlugin = {
     	},
     	
     	loadProjectList: function () {
-    		$j("#previewTemplateItemDialogProjectSelect").append($j('<option></option>').val(null).html("Loading project list..."))
+    		$j("#previewTemplateItemDialogProjectSelect").append($j('<option></option>').val(null).text("Loading project list..."))
 			$j.ajax ({
 				url: window['base_uri'] + '/app/rest/projects',
 				type: "GET",
@@ -473,16 +473,16 @@ WebHooksPlugin = {
 				},
 				success: function (response) {
 					var myselect = $j('<select>');
-					myselect.append( $j('<option></option>').val(null).html("Choose a Project...") );
+					myselect.append( $j('<option></option>').val(null).text("Choose a Project...") );
 					$j(response.project).each(function(index, project) {
 						//console.log(project);
 						if (project.id === '_Root') { 
-							myselect.append( $j('<option></option>').val(project.id).html(project.id) );
+							myselect.append( $j('<option></option>').val(project.id).text(project.id) );
 						} else {
-							myselect.append( $j('<option></option>').val(project.id).html(htmlEscape(project.name)) );
+							myselect.append( $j('<option></option>').val(project.id).text(project.name) );
 						}
 					});
-					$j("#previewTemplateItemDialogProjectSelect").empty().append(myselect.html()).off().change(
+					$j("#previewTemplateItemDialogProjectSelect").empty().append(myselect).off().change(
 							function() {
 								WebHooksPlugin.PreviewTemplateItemDialog.loadBuildList( $j(this).val() );
 								WebHooksPlugin.PreviewTemplateItemDialog.loadWebHookList( $j(this).val() );
@@ -507,7 +507,7 @@ WebHooksPlugin = {
 	   			locator = '';
 	   		}
     		
-    		$j("#previewTemplateItemDialogBuildSelect").empty().append($j('<option></option>').val(null).html("Loading build history..."))
+    		$j("#previewTemplateItemDialogBuildSelect").empty().append($j('<option></option>').val(null).text("Loading build history..."))
     		$j.ajax ({
     			url: window['base_uri'] + '/app/rest/builds?locator=' + locator
     					+ "state:finished&fields=build(id,number,status,finishDate,buildType(id,name))",
@@ -517,18 +517,18 @@ WebHooksPlugin = {
     			},
     			success: function (response) {
     				var myselect = $j('<select>');
-    				myselect.append( $j('<option></option>').val(null).html("Choose a Build...") );
+    				myselect.append( $j('<option></option>').val(null).text("Choose a Build...") );
     				$j(response.build).each(function(index, build) {
     					//console.log(build);
-    					var desc = htmlEscape(build.buildType.name) 
+    					var desc = build.buildType.name)
     							  + "#" + build.number 
     							  + " - " + build.status + " ("
     							  + moment(build.finishDate, moment.ISO_8601).fromNow()
     							  + ")";
     					
-						myselect.append( $j('<option></option>').val(build.id).html(desc) );
+						myselect.append( $j('<option></option>').val(build.id).text(desc) );
     				});
-    				$j("#previewTemplateItemDialogBuildSelect").empty().append(myselect.html());
+    				$j("#previewTemplateItemDialogBuildSelect").empty().append(myselect);
     	    		$j("#previewTemplateItemDialogBuildSelect").off().change( function() {
         				WebHooksPlugin.PreviewTemplateItemDialog.renderPreview();
     	    		});
@@ -536,7 +536,7 @@ WebHooksPlugin = {
     			error: function (response) {
     				if (response.status == 404) {
     					$j("#previewTemplateItemDialogBuildSelect").empty().append(
-    							$j('<option></option>').val(null).html("No builds found. Choose a different project")
+    							$j('<option></option>').val(null).text("No builds found. Choose a different project.")
     						);
     				} else {
 	    				console.log(response);
@@ -549,14 +549,14 @@ WebHooksPlugin = {
     	loadBuildEventList: function () {
     		var selectedItem = $j("#previewTemplateItemDialogBuildStateSelect").val();
 			var myselect = $j('<select>');
-			myselect.append( $j('<option></option>').val(null).html("Choose a Build Event to simulate...") );
+			myselect.append( $j('<option></option>').val(null).text("Choose a Build Event to simulate...") );
     		$j("#editTemplateItemForm input.buildState[type=checkbox]").each(function (index, checkbox) {
     			var label = checkbox.nextSibling.nodeValue;
     			var isChecked = $j('input#' + checkbox.id).is(':checked');
     			if (isChecked) {
-    				myselect.append( $j('<option></option>').val(checkbox.id).html(label) );
+    				myselect.append( $j('<option></option>').val(checkbox.id).text(label) );
     			} else {
-    				myselect.append( $j('<option></option>').val(checkbox.id).html(label).attr("disabled", "disabled") );
+    				myselect.append( $j('<option></option>').val(checkbox.id).text(label).attr("disabled", "disabled") );
     				if (checkbox.id === selectedItem) {
     					//
     					// The previously selected item is now disabled, so clear the selection
@@ -566,7 +566,7 @@ WebHooksPlugin = {
     			}
     			console.log("Found checkbox: " + checkbox.name + " : " + label + " : " + isChecked);
     		});
-    		$j("#previewTemplateItemDialogBuildStateSelect").empty().append(myselect.html());
+    		$j("#previewTemplateItemDialogBuildStateSelect").empty().append(myselect);
     		$j("#previewTemplateItemDialogBuildStateSelect").val(selectedItem);
     		$j("#previewTemplateItemDialogBuildStateSelect").off().change( function() {
     				WebHooksPlugin.PreviewTemplateItemDialog.renderPreview();
@@ -579,7 +579,7 @@ WebHooksPlugin = {
     			$j("#previewTemplateItemDialogWebHookSelect").empty();
     			return;
     		}
-    		$j("#previewTemplateItemDialogWebHookSelect").empty().append($j('<option></option>').val(null).html("Loading project WebHooks ..."))
+    		$j("#previewTemplateItemDialogWebHookSelect").empty().append($j('<option></option>').val(null).text("Loading project WebHooks ..."))
     		$j.ajax ({
     			url: window['base_uri'] + '/app/rest/webhooks/' + projectId + "?fields=$short",
     			type: "GET",
@@ -589,12 +589,12 @@ WebHooksPlugin = {
     			success: function (response) {
     				if (response.count === 0) {
     					$j("#previewTemplateItemDialogWebHookSelect").empty().append(
-    							$j('<option></option>').val(null).html("No webhooks found. Choose a different project or specify URL")
+    							$j('<option></option>').val(null).text("No WebHooks found. Choose a different project or specify a URL.")
     						);
     					WebHooksPlugin.PreviewTemplateItemDialog.handleWebHookListChange(null); // Enable the URL input box.
     				} else {
 	    				var myselect = $j('<select>');
-	    				myselect.append( $j('<option></option>').val(null).html("Choose a WebHook... (or enter a URL below)") );
+	    				myselect.append( $j('<option></option>').val(null).text("Choose a WebHook (or enter a URL below)...") );
 	    				$j(response.webhooks).each(function(index, webhook) {
 	    					//console.log(webhook);
 	    					var desc = WebHooksPlugin.PreviewTemplateItemDialog.elipsizeUrl(webhook.url)
@@ -602,9 +602,9 @@ WebHooksPlugin = {
 	    							  + webhook.format + " :: " + webhook.template
 	    							  + ")";
 	    					
-							myselect.append( $j('<option></option>').val(webhook.id).html(htmlEscape(desc)) );
+							myselect.append( $j('<option></option>').val(webhook.id).text(desc) );
 	    				});
-	    				$j("#previewTemplateItemDialogWebHookSelect").empty().append(myselect.html()).off().change(
+	    				$j("#previewTemplateItemDialogWebHookSelect").empty().append(myselect).off().change(
 								function() {
 									WebHooksPlugin.PreviewTemplateItemDialog.handleWebHookListChange( $j(this).val() );
 									WebHooksPlugin.PreviewTemplateItemDialog.renderPreview();
@@ -614,7 +614,7 @@ WebHooksPlugin = {
     			error: function (response) {
     				if (response.status == 404) {
     					$j("#previewTemplateItemDialogWebHookSelect").empty().append(
-    							$j('<option></option>').val(null).html("No webhooks found. Choose a different project or specify URL")
+    							$j('<option></option>').val(null).text("No WebHooks found. Choose a different project or specify a URL.")
     						);
     					WebHooksPlugin.PreviewTemplateItemDialog.handleWebHookListChange(null); // Enable the URL input box.
     				} else {
@@ -666,6 +666,7 @@ WebHooksPlugin = {
     				},
     				success: function (response) {
     					console.log(response.responseText);
+						// Assuming safe:
 						$j('#currentTemplatePreview').html(response.responseText);
 						hljs.highlightBlock($j('#currentTemplatePreview pre code'));
     					$j('pre code').each(function(i, block) {
@@ -675,9 +676,11 @@ WebHooksPlugin = {
     				error: function (response) {
     					console.log(response);
     					if (response.status === 422) {
+						// Assuming safe:
     						$j('#currentTemplatePreview').html(response.responseText);
     					} else {
     					
+						// Assuming safe:
 	    					$j('#currentTemplatePreview').html(response.responseText);
 	    					//hljs.highlightBlock($j('#currentTemplatePreview pre code'));
 	    					
@@ -726,14 +729,14 @@ WebHooksPlugin = {
 					var ul = $j('<ul>');
 					
 					if (response.error) {
-						ul.append($j('<li/>').html("Error: " + htmlEscape(response.error.message) + " (" + response.error.errorCode + ")"));
+						ul.append($j('<li/>').text("Error: " + response.error.message + " (" + response.error.errorCode + ")"));
 					} else {
-						ul.append($j('<li/>').html("Success: " + htmlEscape(response.statusReason) + " (" + response.statusCode + ")"));
+						ul.append($j('<li/>').text("Success: " + response.statusReason + " (" + response.statusCode + ")"));
 					}
-					ul.append($j('<li/>').html("URL: " + htmlEscape(response.url)));
-					ul.append($j('<li/>').html("Duration: " + response.executionTime + " @ " + moment(response.dateTime, moment.ISO_8601).format("dddd, MMMM Do YYYY, h:mm:ss a")));
+					ul.append($j('<li/>').text("URL: " + response.url));
+					ul.append($j('<li/>').text("Duration: " + response.executionTime + " @ " + moment(response.dateTime, moment.ISO_8601).format("dddd, MMMM Do YYYY, h:mm:ss a")));
 					
-					$j("#previewTempleteItemDialogAjaxResult").empty().append(ul.html());
+					$j("#previewTempleteItemDialogAjaxResult").empty().append(ul);
 					console.log(response);
 				},
 				error: function (response) {
@@ -764,7 +767,7 @@ WebHooksPlugin = {
     		this.cleanErrors();
     		this.showCentered();
     		
-    		$j("#previewTemplateItemDialog h3.dialogTitle").html("Preview &amp; Test Build Event Template");
+    		$j("#previewTemplateItemDialog h3.dialogTitle").text("Preview & Test Build Event Template");
     		
     		if ( ! $j("#previewTemplateItemDialogProjectSelect").val()) {
     			this.loadProjectList();
@@ -1084,12 +1087,3 @@ WebHooksPlugin = {
     	}
     }))
 };
-
-function htmlEscape(str) {
-	return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}

--- a/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/js/editWebhookTemplate.js
+++ b/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/js/editWebhookTemplate.js
@@ -87,7 +87,7 @@ WebHooksPlugin = {
 			this.clearEditor();
 
             $j("input[id='WebhookTemplateaction']").val(action);
-            $j(".dialogTitle").html(title);
+            $j(".dialogTitle").text(title);
             this.cleanFields(data);
             this.cleanErrors();
             this.showCentered();
@@ -98,7 +98,7 @@ WebHooksPlugin = {
         	this.getTemplateDataOrGetParentOnFailure(data.templateId, data.templateNumber, action)
         	
         	$j("input[id='WebhookTemplateaction']").val(action);
-        	$j(".dialogTitle").html(title);
+        	$j(".dialogTitle").text(title);
         	this.cleanFields(data);
         	this.cleanErrors();
         	this.showCentered();
@@ -109,7 +109,7 @@ WebHooksPlugin = {
         	this.getWebHookTemplateData(data.templateId, data.templateNumber, action);
         	
             $j("input[id='WebhookTemplateaction']").val(action);
-            $j(".dialogTitle").html(title);
+            $j(".dialogTitle").text(title);
             this.cleanFields(data);
             this.cleanErrors();
             this.showCentered();
@@ -803,7 +803,7 @@ WebHooksPlugin = {
     	
     	showDialog: function (title, action, data) {
     		$j("input[id='WebhookTemplateaction']").val(action);
-    		$j(".dialogTitle").html(title);
+    		$j(".dialogTitle").text(title);
     		this.cleanFields(data);
     		this.cleanErrors();
     		this.showCentered();
@@ -878,7 +878,7 @@ WebHooksPlugin = {
     	
     	showDialog: function (title, action, data) {
     		$j("input[id='WebhookTemplateaction']").val(action);
-    		$j(".dialogTitle").html(title);
+    		$j(".dialogTitle").text(title);
     		this.cleanFields(data);
     		this.cleanErrors();
     		this.showCentered();
@@ -955,7 +955,7 @@ WebHooksPlugin = {
     		this.getTemplateData(templateId, action);
     		
     		$j("input[id='WebhookTemplateaction']").val(action);
-    		$j(".dialogTitle").html(title);
+    		$j(".dialogTitle").text(title);
     		
     		if (action == 'copyTemplate') {
 	    		$j("#editTemplateForm .templateEdit").hide();

--- a/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/webhookEdit.jsp
+++ b/tcwebhooks-web-ui/src/main/resources/buildServerResources/WebHook/webhookEdit.jsp
@@ -106,7 +106,7 @@
 	
 	function renderPreviewOnChange() {
 		if ($j('#payloadFormatHolder').val()) {
-			$j('#currentTemplateName').html(htmlEscape(lookupTemplateName($j('#payloadFormatHolder').val())));
+			$j('#currentTemplateName').text(lookupTemplateName($j('#payloadFormatHolder').val()));
 		} else {
 			$j('#currentTemplateName').html("&nbsp;");
 		}
@@ -158,8 +158,8 @@
 					success:(function(data){
 									if(data.errored) {
 										$j('#webhookPreviewRendered').html(
-												"<b>An error occured building the payload preview</b><br><div style='padding:1em;'>" +
-												data.exception.detailMessage + "</div>");
+												"<b>An error occured building the payload preview</b><br>").append(
+												$j("<div style='padding:1em;'></div>").text(data.exception.detailMessage));
 									} else {
 										$j('#webhookPreviewRendered').html(data.html);
 										


### PR DESCRIPTION
As discussed in #137, replaced usages of `.html()` with `.text()` where it seemed unused / potentially hazardous. However, some assumptions had to be left alone (which have been marked). Some code had to be or was reworked to work with this.