### PR TITLE
add support of excluding vcs modification from webhook during to perf…

### DIFF
--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHooksChange.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHooksChange.java
@@ -3,6 +3,8 @@ package webhook.teamcity.payload.content;
 import java.util.ArrayList;
 import java.util.List;
 
+
+import jetbrains.buildServer.serverSide.TeamCityProperties;
 import jetbrains.buildServer.vcs.SVcsModification;
 import jetbrains.buildServer.vcs.VcsFileModification;
 import jetbrains.buildServer.vcs.VcsRootInstance;
@@ -33,8 +35,10 @@ public class WebHooksChange {
 		change.setComment(modification.getDescription());
 		change.setUsername(modification.getUserName());
 		change.setVcsRoot(tryGetVcsRootName(modification));
-		for (VcsFileModification fileModification: modification.getChanges()){
-			change.files.add(fileModification.getRelativeFileName());
+		if (TeamCityProperties.getBooleanOrTrue("webhook.includeVcsFileModification")) {
+			for (VcsFileModification fileModification : modification.getChanges()) {
+				change.files.add(fileModification.getRelativeFileName());
+			}
 		}
 		return change;
 	}


### PR DESCRIPTION
Hi there,
I'm working in TeamCity and there were a few requests from TeamCity users regarding significant performance degradation caused by loading unnecessary vcs files during webhook generation. As a quick fix, we suggest using the TeamCity property "webhook.includeVcsFileModification" as a flag that allows to disable the loading of vcs files.