### PR TITLE
Add ability to limit or exclude vcs file list whilst building payload

### DIFF
--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHooksChange.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHooksChange.java
@@ -3,11 +3,11 @@ package webhook.teamcity.payload.content;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jetbrains.annotations.Nullable;
+
 import jetbrains.buildServer.vcs.SVcsModification;
 import jetbrains.buildServer.vcs.VcsFileModification;
 import jetbrains.buildServer.vcs.VcsRootInstance;
-import org.jetbrains.annotations.Nullable;
-
 
 public class WebHooksChange {
 
@@ -28,19 +28,24 @@ public class WebHooksChange {
 		return vcsRoot.getName();
 	}
 
-	public static WebHooksChange build(SVcsModification modification) {
+
+
+	public static WebHooksChange build(SVcsModification modification, boolean includeVcsFileModifications) {
 		WebHooksChange change = new WebHooksChange();
 		change.setComment(modification.getDescription());
 		change.setUsername(modification.getUserName());
 		change.setVcsRoot(tryGetVcsRootName(modification));
-		for (VcsFileModification fileModification: modification.getChanges()){
-			change.files.add(fileModification.getRelativeFileName());
+		if (includeVcsFileModifications) {
+			change.files = new ArrayList<>();
+			for (VcsFileModification fileModification: modification.getChanges()){
+				change.files.add(fileModification.getRelativeFileName());
+			}
 		}
 		return change;
 	}
 
 
-	private List<String> files = new ArrayList<>();
+	private List<String> files;
 	private String comment;
 	private String username;
 	private String vcsRoot;

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHooksChangeBuilder.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHooksChangeBuilder.java
@@ -8,11 +8,11 @@ import jetbrains.buildServer.vcs.SVcsModification;
 public class WebHooksChangeBuilder{
 	private WebHooksChangeBuilder(){}
 	
-	public static List<WebHooksChanges> build (List<SVcsModification> mods){
+	public static List<WebHooksChanges> build (List<SVcsModification> mods, boolean includeVcsFileModifications){
 		List<WebHooksChanges> changes = new ArrayList<>();
 		
 		for (SVcsModification modification: mods){
-			changes.add(new WebHooksChanges(modification.getDisplayVersion(), WebHooksChange.build(modification)));
+			changes.add(new WebHooksChanges(modification.getDisplayVersion(), WebHooksChange.build(modification, includeVcsFileModifications)));
 		}
 		return changes;
 	}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/format/WebHookPayloadJson.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/format/WebHookPayloadJson.java
@@ -52,6 +52,7 @@ public class WebHookPayloadJson extends WebHookPayloadGeneric implements WebHook
         xstream.setMode(XStream.NO_REFERENCES);
         xstream.registerConverter(new ExtraParametersMapToJsonConvertor());
         xstream.registerConverter(new UserSingleValueConverter());
+        xstream.autodetectAnnotations(true);
         xstream.alias("build", WebHookPayloadContent.class);
         /* For some reason, the items are coming back as "@name" and "@value"
          * so strip those out with a regex.

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/format/WebHookPayloadXml.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/format/WebHookPayloadXml.java
@@ -61,6 +61,7 @@ public class WebHookPayloadXml extends WebHookPayloadGeneric {
 		XStream xstream = new XStream();
         xstream.setMode(XStream.NO_REFERENCES);
         xstream.registerConverter(new ExtraParametersMapToXmlConvertor());
+        xstream.autodetectAnnotations(true);
         xstream.alias("build", WebHookPayloadContent.class);
 		return xstream.toXML(content);
 	}

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/payload/content/WebHookPayloadContentChangesTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/payload/content/WebHookPayloadContentChangesTest.java
@@ -1,0 +1,334 @@
+package webhook.teamcity.payload.content;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import jetbrains.buildServer.StatusDescriptor;
+import jetbrains.buildServer.messages.Status;
+import jetbrains.buildServer.serverSide.SBuild;
+import jetbrains.buildServer.serverSide.SBuildAgent;
+import jetbrains.buildServer.serverSide.SBuildServer;
+import jetbrains.buildServer.serverSide.SFinishedBuild;
+import jetbrains.buildServer.serverSide.SProject;
+import jetbrains.buildServer.serverSide.SRunningBuild;
+import jetbrains.buildServer.serverSide.TriggeredBy;
+import jetbrains.buildServer.vcs.SVcsModification;
+import jetbrains.buildServer.vcs.VcsFileModification;
+import jetbrains.buildServer.vcs.VcsRootInstance;
+import webhook.teamcity.BuildStateEnum;
+import webhook.teamcity.MockSBuildType;
+import webhook.teamcity.payload.WebHookPayloadDefaultTemplates;
+import webhook.teamcity.payload.variableresolver.VariableMessageBuilder;
+import webhook.teamcity.payload.variableresolver.VariableResolver;
+import webhook.teamcity.payload.variableresolver.VariableResolverFactory;
+
+public class WebHookPayloadContentChangesTest {
+	
+	@Mock
+	VariableResolverFactory variableResolverFactory;
+	
+	@Mock
+	VariableResolver variableResolver;
+	
+	@Mock
+	VariableMessageBuilder variableMessageBuilder;
+	
+	@Mock
+	SBuildServer sBuildServer;
+	
+	@Mock
+	SFinishedBuild previousBuild;
+	
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+		when(sBuildServer.getRootUrl()).thenReturn("http://localhost/");
+		when(variableResolverFactory.createVariableMessageBuilder(any(), any())).thenReturn(variableMessageBuilder);
+	}
+
+	@Test
+	public void testTenChangedFilesFoundWithDefaultLimits() {
+		
+		SBuild sRunningBuild = getMockedBuild();
+		List<SVcsModification> mod = getMockedChanges(10);
+		when(sRunningBuild.getContainingChanges()).thenReturn(mod);
+		
+		WebHookPayloadContent content = new WebHookPayloadContent(
+				variableResolverFactory, sBuildServer, 
+				sRunningBuild, previousBuild, 
+				BuildStateEnum.BEFORE_BUILD_FINISHED, 
+				new ExtraParametersMap(new HashMap<String, String>()), 
+				new ExtraParametersMap(new HashMap<String, String>()), 
+				WebHookPayloadDefaultTemplates.getDefaultEnabledPayloadTemplates());
+		
+		assertEquals(100, content.getMaxChangeFileListSize());
+		assertEquals(10, content.getChangeFileListCount());
+		assertEquals(10, content.getChanges().get(0).getChange().getFiles().size());
+		// Verify that the changes were loaded once
+		Mockito.verify(mod.get(0), Mockito.times(1)).getChanges();
+		assertFalse(content.isMaxChangeFileListCountExceeded());
+	}
+	
+	@Test
+	public void test80ChangedFilesFoundAcross4VcsRootsWithDefaultLimits() {
+		
+		SBuild sRunningBuild = getMockedBuild();
+		List<SVcsModification> mod = getMockedChanges(4, 20);
+		when(sRunningBuild.getContainingChanges()).thenReturn(mod);
+		
+		WebHookPayloadContent content = new WebHookPayloadContent(
+				variableResolverFactory, sBuildServer, 
+				sRunningBuild, previousBuild, 
+				BuildStateEnum.BEFORE_BUILD_FINISHED, 
+				new ExtraParametersMap(new HashMap<String, String>()), 
+				new ExtraParametersMap(new HashMap<String, String>()), 
+				WebHookPayloadDefaultTemplates.getDefaultEnabledPayloadTemplates());
+		
+		assertEquals(100, content.getMaxChangeFileListSize());
+		assertEquals(80, content.getChangeFileListCount());
+		assertEquals(20, content.getChanges().get(0).getChange().getFiles().size());
+		// Verify that the changes were loaded once
+		Mockito.verify(mod.get(0), Mockito.times(1)).getChanges();
+		assertFalse(content.isMaxChangeFileListCountExceeded());
+	}
+	
+	@Test
+	public void testChangedFilesIsNullWithDefaultLimitsAnd500Files() {
+		
+		SBuild sRunningBuild = getMockedBuild();
+		List<SVcsModification> mod = getMockedChanges(500);
+		when(sRunningBuild.getContainingChanges()).thenReturn(mod);
+		
+		WebHookPayloadContent content = new WebHookPayloadContent(
+				variableResolverFactory, sBuildServer, 
+				sRunningBuild, previousBuild, 
+				BuildStateEnum.BEFORE_BUILD_FINISHED, 
+				new ExtraParametersMap(new HashMap<String, String>()), 
+				new ExtraParametersMap(new HashMap<String, String>()), 
+				WebHookPayloadDefaultTemplates.getDefaultEnabledPayloadTemplates());
+		
+		assertEquals(100, content.getMaxChangeFileListSize());
+		assertEquals(500, content.getChangeFileListCount());
+		assertNull(content.getChanges().get(0).getChange().getFiles());
+		// Verify that the changes were never loaded. 
+		// This is the expensive operation we are trying to avoid.
+		Mockito.verify(mod.get(0), Mockito.times(0)).getChanges();
+		assertTrue(content.isMaxChangeFileListCountExceeded());
+	}
+	
+	@Test
+	public void testChangedFilesIsNullWithDefaultLimitsAnd120FilesAcrossSixVcsRoots() {
+		
+		SBuild sRunningBuild = getMockedBuild();
+		List<SVcsModification> mod = getMockedChanges(6,20);
+		when(sRunningBuild.getContainingChanges()).thenReturn(mod);
+		
+		WebHookPayloadContent content = new WebHookPayloadContent(
+				variableResolverFactory, sBuildServer, 
+				sRunningBuild, previousBuild, 
+				BuildStateEnum.BEFORE_BUILD_FINISHED, 
+				new ExtraParametersMap(new HashMap<String, String>()), 
+				new ExtraParametersMap(new HashMap<String, String>()), 
+				WebHookPayloadDefaultTemplates.getDefaultEnabledPayloadTemplates());
+		
+		assertEquals(100, content.getMaxChangeFileListSize());
+		assertEquals(120, content.getChangeFileListCount());
+		assertNull(content.getChanges().get(0).getChange().getFiles());
+		// Verify that the changes were never loaded. 
+		// This is the expensive operation we are trying to avoid.
+		Mockito.verify(mod.get(0), Mockito.times(0)).getChanges();
+		assertTrue(content.isMaxChangeFileListCountExceeded());
+	}
+	
+	@Test
+	public void testChangedFilesIsNullWith50FilesButLimitIs10SetViaTeamCityBuildParameter() {
+		
+		SBuild sRunningBuild = getMockedBuild();
+		Map<String,String> teamCityMap = new HashMap<>();
+		teamCityMap.put("webhook.maxChangeFileListSize", "10");
+		List<SVcsModification> mod = getMockedChanges(50);
+		when(sRunningBuild.getContainingChanges()).thenReturn(mod);
+		
+		WebHookPayloadContent content = new WebHookPayloadContent(
+				variableResolverFactory, sBuildServer, 
+				sRunningBuild, previousBuild, 
+				BuildStateEnum.BEFORE_BUILD_FINISHED, 
+				new ExtraParametersMap(new HashMap<String, String>()), 
+				new ExtraParametersMap(teamCityMap), 
+				WebHookPayloadDefaultTemplates.getDefaultEnabledPayloadTemplates());
+		
+		assertEquals(10, content.getMaxChangeFileListSize());
+		assertEquals(50, content.getChangeFileListCount());
+		assertNull(content.getChanges().get(0).getChange().getFiles());
+		// Verify that the changes were never loaded. 
+		// This is the expensive operation we are trying to avoid.
+		Mockito.verify(mod.get(0), Mockito.times(0)).getChanges();
+		assertTrue(content.isMaxChangeFileListCountExceeded());
+	}
+	
+	@Test
+	public void testChangedFilesIsNullWith50FilesButLimitIs20SetViaWebHookProperty() {
+		
+		SBuild sRunningBuild = getMockedBuild();
+		Map<String,String> propertiesMap = new HashMap<>();
+		propertiesMap.put("maxChangeFileListSize", "20");
+		List<SVcsModification> mod = getMockedChanges(50);
+		when(sRunningBuild.getContainingChanges()).thenReturn(mod);
+		
+		WebHookPayloadContent content = new WebHookPayloadContent(
+				variableResolverFactory, sBuildServer, 
+				sRunningBuild, previousBuild, 
+				BuildStateEnum.BEFORE_BUILD_FINISHED, 
+				new ExtraParametersMap(propertiesMap), 
+				new ExtraParametersMap(new HashMap<String, String>()), 
+				WebHookPayloadDefaultTemplates.getDefaultEnabledPayloadTemplates());
+		
+		assertEquals(20, content.getMaxChangeFileListSize());
+		assertEquals(50, content.getChangeFileListCount());
+		assertNull(content.getChanges().get(0).getChange().getFiles());
+		// Verify that the changes were never loaded. 
+		// This is the expensive operation we are trying to avoid.
+		Mockito.verify(mod.get(0), Mockito.times(0)).getChanges();
+		assertTrue(content.isMaxChangeFileListCountExceeded());
+	}
+	
+	@Test
+	public void testChangedFilesContainsAllWhenUnlimitedViaWebHookProperty() {
+		
+		SBuild sRunningBuild = getMockedBuild();
+		Map<String,String> propertiesMap = new HashMap<>();
+		propertiesMap.put("maxChangeFileListSize", "-1");
+		List<SVcsModification> mod = getMockedChanges(500);
+		when(sRunningBuild.getContainingChanges()).thenReturn(mod);
+		
+		WebHookPayloadContent content = new WebHookPayloadContent(
+				variableResolverFactory, sBuildServer, 
+				sRunningBuild, previousBuild, 
+				BuildStateEnum.BEFORE_BUILD_FINISHED, 
+				new ExtraParametersMap(propertiesMap), 
+				new ExtraParametersMap(new HashMap<String, String>()), 
+				WebHookPayloadDefaultTemplates.getDefaultEnabledPayloadTemplates());
+		
+		assertEquals(-1, content.getMaxChangeFileListSize());
+		assertEquals(500, content.getChangeFileListCount());
+		assertEquals(500, content.getChanges().get(0).getChange().getFiles().size());
+		Mockito.verify(mod.get(0), Mockito.times(1)).getChanges();
+		assertFalse(content.isMaxChangeFileListCountExceeded());
+	}
+	
+	@Test
+	public void testChangedFilesContainsAllFromMulitpleChangesWhenUnlimitedViaWebHookProperty() {
+		
+		SBuild sRunningBuild = getMockedBuild();
+		Map<String,String> propertiesMap = new HashMap<>();
+		propertiesMap.put("maxChangeFileListSize", "-1");
+		List<SVcsModification> mod = getMockedChanges(5, 500);
+		when(sRunningBuild.getContainingChanges()).thenReturn(mod);
+		
+		WebHookPayloadContent content = new WebHookPayloadContent(
+				variableResolverFactory, sBuildServer, 
+				sRunningBuild, previousBuild, 
+				BuildStateEnum.BEFORE_BUILD_FINISHED, 
+				new ExtraParametersMap(propertiesMap), 
+				new ExtraParametersMap(new HashMap<String, String>()), 
+				WebHookPayloadDefaultTemplates.getDefaultEnabledPayloadTemplates());
+		
+		assertEquals(-1, content.getMaxChangeFileListSize());
+		assertEquals(2500, content.getChangeFileListCount());
+		
+		assertEquals(500, content.getChanges().get(0).getChange().getFiles().size());
+		assertEquals(500, content.getChanges().get(1).getChange().getFiles().size());
+		assertEquals(500, content.getChanges().get(2).getChange().getFiles().size());
+		assertEquals(500, content.getChanges().get(3).getChange().getFiles().size());
+		assertEquals(500, content.getChanges().get(4).getChange().getFiles().size());
+		Mockito.verify(mod.get(0), Mockito.times(1)).getChanges();
+		Mockito.verify(mod.get(1), Mockito.times(1)).getChanges();
+		Mockito.verify(mod.get(2), Mockito.times(1)).getChanges();
+		Mockito.verify(mod.get(3), Mockito.times(1)).getChanges();
+		Mockito.verify(mod.get(4), Mockito.times(1)).getChanges();
+		assertFalse(content.isMaxChangeFileListCountExceeded());
+	}
+	
+	@Test
+	public void testChangedFilesIsNullWhenDisabledViaTeamCityBuildParameter() {
+		
+		SBuild sRunningBuild = getMockedBuild();
+		Map<String,String> teamcityBuildParameters = new HashMap<>();
+		teamcityBuildParameters.put("webhook.maxChangeFileListSize", "0");
+		List<SVcsModification> mod = getMockedChanges(50);
+		when(sRunningBuild.getContainingChanges()).thenReturn(mod);
+		
+		WebHookPayloadContent content = new WebHookPayloadContent(
+				variableResolverFactory, sBuildServer, 
+				sRunningBuild, previousBuild, 
+				BuildStateEnum.BEFORE_BUILD_FINISHED, 
+				new ExtraParametersMap(new HashMap<String, String>()), 
+				new ExtraParametersMap(teamcityBuildParameters), 
+				WebHookPayloadDefaultTemplates.getDefaultEnabledPayloadTemplates());
+		
+		assertEquals(0, content.getMaxChangeFileListSize());
+		assertEquals(50, content.getChangeFileListCount());
+		assertNull(content.getChanges().get(0).getChange().getFiles());
+		// Verify that the changes were never loaded. 
+		// This is the expensive operation we are trying to avoid.
+		Mockito.verify(mod.get(0), Mockito.times(0)).getChanges();
+		assertTrue(content.isMaxChangeFileListCountExceeded());
+	}
+
+	private List<SVcsModification> getMockedChanges(int fileNumber) {
+		return getMockedChanges(1, fileNumber);
+	}
+	
+	private List<SVcsModification> getMockedChanges(int vcsNumber, int fileNumber) {
+		List<SVcsModification> mods = new ArrayList<>();
+		for (int i = 0; i < vcsNumber; i++) {
+			SVcsModification mod = mock(SVcsModification.class);
+			VcsRootInstance vcs = mock(VcsRootInstance.class);
+			when(vcs.getVcsName()).thenReturn("myVcsName" + i);
+			when(mod.getVcsRoot()).thenReturn(vcs);
+			when(mod.getChangeCount()).thenReturn(fileNumber);
+			List<VcsFileModification> files = new ArrayList<>();
+			for (int j = 0; j < fileNumber; j++) {
+				VcsFileModification fileMod = mock(VcsFileModification.class);
+				when(fileMod.getRelativeFileName()).thenReturn("myFile" + j + ".txt");
+				files.add(fileMod);
+			}
+			when(mod.getChanges()).thenReturn(files);
+			mods.add(mod);
+		}
+		return mods;
+	}
+
+	private SBuild getMockedBuild() {
+		SProject sProject = mock(SProject.class);
+		SBuild sBuild = mock(SRunningBuild.class);
+		MockSBuildType sBuildType = new MockSBuildType("My Name", "My Description", "bt01");
+		SBuildAgent buildAgent = mock(SBuildAgent.class);
+		TriggeredBy triggeredBy = mock(TriggeredBy.class);
+		sBuildType.setProject(sProject);
+		when(sBuild.getStartDate()).thenReturn(new Date());
+		when(sBuild.getBuildType()).thenReturn(sBuildType);
+		when(sBuild.getAgent()).thenReturn(buildAgent);
+		when(sBuild.getTriggeredBy()).thenReturn(triggeredBy);
+		when(sBuild.getStatusDescriptor()).thenReturn(new StatusDescriptor(Status.NORMAL, "Running"));
+		return sBuild;
+	}
+
+}


### PR DESCRIPTION
This change includes the following new features:
1. The list of changed VCS files can be disabled.
2. The list of changed VCS files can be disabled if it is too large. The
default value is 100 files across all changes in a build.

NOTE: In the cases where the change list is disabled or too large (1 & 2
above), the payload will contain a `null` files list.
This is preferable to returning an empty list, because the empty list
implies no actual changed files were included in the change.
A null change list will typically be serialised to nothing in JSON or
XML, so the json array or xml element will be missing from the payload.
If your endpoint is expecting these, then it should fail in this
scenario or handle the missing field gracefully.

**Enables control over whether or not to include the list of files in a
change.** This can be enabled in the three ways below, in order of
priority.

1. Add a 'param' named 'includeChangeFileList' to a webhook config by
editing plugin-settings.xml
2. Add a build parameter to a buildType or project called
'webhook.includeChangeFileList'
3. Define a property in teamcity's internal properties file called
'webhook.includeChangeFileList'.

The value must be a string representation of a boolean. eg, "true" or
anything else will evaluate to false.

**Enables control over the maximum number of files changed in a build
before the changed file list is null.** This can be controlled in the
three ways below, in order of priority.

1. Add a 'param' named 'maxChangeFileListSize' to a webhook config by
editing plugin-settings.xml
2. Add a build parameter to a buildType or project called
'webhook.maxChangeFileListSize'
3. Define a property in teamcity's internal properties file called
'webhook.maxChangeFileListSize'

If the total number of files is greater than `maxChangeFileListSize`,
then the change list will be null. See note above.