### PR TITLE
lombok dependency provided scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,4 +89,13 @@
 		<module>tcwebhooks-rest-api</module>
 		<module>tcwebhooks-web-ui</module>
 	</modules>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.12</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
 </project>

--- a/tcwebhooks-core/pom.xml
+++ b/tcwebhooks-core/pom.xml
@@ -174,13 +174,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.12</version>
-			<scope>compile</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.velocity</groupId>
 			<artifactId>velocity</artifactId>
 			<version>1.7</version>


### PR DESCRIPTION
Fix lombok dependency scope - it should have `provided` scope (not compile). It reduces the final build size significantly.