### PR TITLE
Fix null ref exception

### DIFF
--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/ExtraParameters.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/ExtraParameters.java
@@ -118,7 +118,7 @@ public class ExtraParameters extends ArrayList<WebHookParameterModel> {
 					parameter.getForceResolveTeamCityVariable(),
 					parameter.getTemplateEngine());
 			add(newHookParameterModel);
-			Loggers.SERVER.debug("WebHookExtraParameters :: Added WebHookParameter: " + previous.getContext() + " : " + previous.getName());
+			Loggers.SERVER.debug("WebHookExtraParameters :: Added WebHookParameter: " + newHookParameterModel.getContext() + " : " + newHookParameterModel.getName());
 		}
 	}
 	


### PR DESCRIPTION
When using a project based webhook sensitive parameter for a bearer auth token, it throws an error.
```
999 :: Unexpected exception. Please log a bug on GitHub tcplugins/tcWebHooks. Exception was: null
```

Debugging it leads me to [this line](https://github.com/tcplugins/tcWebHooks/blame/master/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/ExtraParameters.java#L121), where it uses `previous` when it could be `null.` It should be using `newHookParameterModel` instead.

Fixes #204.