### PR TITLE
Key cache lookup by project id and unique id

### DIFF
--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookCacheKey.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookCacheKey.java
@@ -1,0 +1,13 @@
+package webhook.teamcity.settings;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.NonNull;
+
+@Data
+public class WebHookCacheKey {
+    @NonNull
+    private String projectInternalId;
+    @NonNull
+    private String webhookId;
+}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookConfig.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookConfig.java
@@ -540,6 +540,11 @@ public class WebHookConfig {
 		this.url = url;
 	}
 
+	/**
+	 * A unique key, within this project.
+	 * If a project is copied, then this key may be duplicated.
+	 * Use <code>getCacheKey</code> as a globally unique id for this webhook
+	 */
 	public String getUniqueKey() {
 		if (this.uniqueKey == null) {
 			this.uniqueKey = generateRandomKey();
@@ -550,6 +555,10 @@ public class WebHookConfig {
 
 	public void setUniqueKey(String uniqueKey) {
 		this.uniqueKey = uniqueKey;
+	}
+
+	public WebHookCacheKey getCacheKey() {
+		return new WebHookCacheKey(projectInternalId, uniqueKey);
 	}
 
 	public String getEnabledListAsString(){

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookSettingsManagerImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookSettingsManagerImpl.java
@@ -48,7 +48,7 @@ public class WebHookSettingsManagerImpl implements WebHookSettingsManager, WebHo
 	private Map<String, WebHookProjectSettings> projectSettingsMap;
 
 	/** A Map of webhook uniqueKey to {@link WebHookConfigEnhanced} */
-	private Map<String, WebHookConfigEnhanced> webhooksEnhanced = new LinkedHashMap<>();
+	private Map<WebHookCacheKey, WebHookConfigEnhanced> webhooksEnhanced = new LinkedHashMap<>();
 
 
 	public WebHookSettingsManagerImpl(
@@ -484,8 +484,8 @@ public class WebHookSettingsManagerImpl implements WebHookSettingsManager, WebHo
 				addTagIfPresent(configEnhanced, c.getTriggerFilters(), "filters", TagType.FILTER);
 				addTagIfPresent(configEnhanced, c.getParams(), "parameters", TagType.PARAMETER);
 
-				this.webhooksEnhanced.put(c.getUniqueKey(), configEnhanced);
-				Loggers.SERVER.debug("WebHookSettingsManagerImpl :: updating webhook: '" + c.getUniqueKey() + "' " + configEnhanced.toString());
+				this.webhooksEnhanced.put(c.getCacheKey(), configEnhanced);
+				Loggers.SERVER.debug("WebHookSettingsManagerImpl :: updating webhook: '" + c.getCacheKey() + "' " + configEnhanced.toString());
 			}
 		} else {
 			Loggers.SERVER.debug("WebHookSettingsManagerImpl :: NOT rebuilding webhook cache. Project not found: " + projectInternalId);

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/settings/WebHookSettingsManagerImplTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/settings/WebHookSettingsManagerImplTest.java
@@ -53,6 +53,10 @@ public class WebHookSettingsManagerImplTest {
 		
 		projectSettings = new WebHookProjectSettings();
 		projectSettings.readFrom(ConfigLoaderUtil.getFullConfigElement(new File("src/test/resources/project-settings-test-elastic.xml")).getChild("webhooks"));
+		projectSettings.getWebHooksConfigs().forEach(c -> {
+			c.setProjectInternalId("project01");
+			c.setProjectExternalId("MyProject");
+		});
 		
 		when(projectSettingsManager.getSettings("project01", "webhooks")).thenReturn(projectSettings);
 		

--- a/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/ProjectWebHooksBean.java
+++ b/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/ProjectWebHooksBean.java
@@ -15,6 +15,7 @@ import webhook.teamcity.BuildState;
 import webhook.teamcity.TeamCityIdResolver;
 import webhook.teamcity.payload.WebHookPayload;
 import webhook.teamcity.payload.WebHookPayloadTemplate;
+import webhook.teamcity.settings.WebHookCacheKey;
 import webhook.teamcity.settings.WebHookConfig;
 import webhook.teamcity.settings.WebHookConfigEnhanced;
 import webhook.teamcity.settings.WebHookProjectSettings;
@@ -26,7 +27,7 @@ public class ProjectWebHooksBean {
 	@Getter private String 	sensibleProjectName;
 	@Getter private String 	sensibleProjectFullName;
 	@Getter private boolean webHooksEnabledForProject;
-	private Map<String, WebhookConfigAndBuildTypeListHolder> webHookList;
+	private Map<WebHookCacheKey, WebhookConfigAndBuildTypeListHolder> webHookList;
 
 	public Collection<WebhookConfigAndBuildTypeListHolder> getWebHookList(){
 		return webHookList.values();
@@ -160,7 +161,7 @@ public class ProjectWebHooksBean {
 													)
 										);
 		}
-		bean.webHookList.put(holder.getUniqueKey(), holder);
+		bean.webHookList.put(holder.getCacheKey(), holder);
 	}
 	
 	private static void addWebHookConfigHolder(ProjectWebHooksBean bean,
@@ -175,7 +176,7 @@ public class ProjectWebHooksBean {
 					)
 					);
 		}
-		bean.webHookList.put(holder.getUniqueKey(), holder);
+		bean.webHookList.put(holder.getCacheKey(), holder);
 	}
 
 }

--- a/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/WebhookConfigAndBuildTypeListHolder.java
+++ b/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/WebhookConfigAndBuildTypeListHolder.java
@@ -15,6 +15,7 @@ import webhook.teamcity.history.GeneralisedWebAddress;
 import webhook.teamcity.payload.PayloadTemplateEngineType;
 import webhook.teamcity.payload.WebHookPayload;
 import webhook.teamcity.payload.WebHookPayloadTemplate;
+import webhook.teamcity.settings.WebHookCacheKey;
 import webhook.teamcity.settings.WebHookConfig;
 import webhook.teamcity.settings.WebHookConfigEnhanced;
 import webhook.teamcity.settings.WebHookConfigEnhanced.Tag;
@@ -23,6 +24,7 @@ import webhook.teamcity.settings.WebHookConfigEnhanced.Tag;
 public class WebhookConfigAndBuildTypeListHolder {
 	private String url;
 	private String uniqueKey;
+	private WebHookCacheKey cacheKey;
 	private boolean enabled;
 	private String payloadTemplate;
 	private String payloadFormatForWeb = "Unknown";
@@ -51,6 +53,7 @@ public class WebhookConfigAndBuildTypeListHolder {
 	public WebhookConfigAndBuildTypeListHolder(WebHookConfig config, Collection<WebHookPayload> registeredPayloads, List<WebHookPayloadTemplate> templateList) {
 		url = config.getUrl();
 		uniqueKey = config.getUniqueKey();
+		cacheKey = config.getCacheKey();
 		enabled = config.getEnabled();
 		hideSecureValues = config.isHideSecureValues();
 		payloadTemplate = config.getPayloadTemplate();


### PR DESCRIPTION
To avoid duplicates when projects are copied.

Fixes https://github.com/tcplugins/tcWebHooks/issues/238.

Note: I haven't tested this, as I'm struggling to compile locally. (I'm also not a java developer, so there's a lot of things that I dont know that I dont know :smile:).