### PR TITLE
Use plugin specific logger, rather than server/activities log

### DIFF
--- a/tcwebhooks-core/src/main/java/webhook/WebHookImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/WebHookImpl.java
@@ -10,6 +10,7 @@ import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.apache.http.Consts;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -35,7 +36,6 @@ import jetbrains.buildServer.serverSide.SFinishedBuild;
 import lombok.Getter;
 import webhook.teamcity.BuildState;
 import webhook.teamcity.BuildStateEnum;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.WebHookExecutionException;
 import webhook.teamcity.auth.WebHookAuthConfig;
 import webhook.teamcity.auth.WebHookAuthenticator;
@@ -46,6 +46,8 @@ import webhook.teamcity.settings.WebHookHeaderConfig;
 
 
 public class WebHookImpl implements WebHook {
+	private static final Logger LOG = Logger.getInstance(WebHookImpl.class.getName());
+
 	private String proxyHost;
 	private Integer proxyPort = 0;
 	private String proxyUsername;
@@ -156,33 +158,33 @@ public class WebHookImpl implements WebHook {
 			HttpResponse httpResponse = null;
 		    try {
 		    	this.webhookStats.setRequestStarting();
-		    	Loggers.SERVER.debug("WebHookImpl::  Connect timeout(millis): " + this.requestConfig.getConnectTimeout());
-		    	Loggers.SERVER.debug("WebHookImpl:: Response timeout(millis): " + this.requestConfig.getSocketTimeout());
+		    	LOG.debug("WebHookImpl::  Connect timeout(millis): " + this.requestConfig.getConnectTimeout());
+		    	LOG.debug("WebHookImpl:: Response timeout(millis): " + this.requestConfig.getSocketTimeout());
 		    	httpResponse = client.execute(httppost, context);
 		        this.webhookStats.setRequestCompleted(httpResponse.getStatusLine().getStatusCode(), httpResponse.getStatusLine().getReasonPhrase());
 		        this.webhookStats.setResponseHeaders(httpResponse.getAllHeaders());
 		        
-		        if (Loggers.SERVER.isDebugEnabled()) {
+		        if (LOG.isDebugEnabled()) {
 		        	// Log headers
-		        	Loggers.SERVER.debug("WebHookImpl::  --- Begin Server Response Headers ---");
+		        	LOG.debug("WebHookImpl::  --- Begin Server Response Headers ---");
 		        	for (Header header : httpResponse.getAllHeaders()) {
-		        		Loggers.SERVER.debug( header.getName() + " : " + header.getValue() );
+		        		LOG.debug( header.getName() + " : " + header.getValue() );
 		        	}
-		        	Loggers.SERVER.debug("WebHookImpl::  --- End Server Response Headers ---");
+		        	LOG.debug("WebHookImpl::  --- End Server Response Headers ---");
 		        	
 		        	// Log body
-		        	Loggers.SERVER.debug("WebHookImpl::  --- Begin Server Response Body ---");
+		        	LOG.debug("WebHookImpl::  --- Begin Server Response Body ---");
 			        try {
 			        	HttpEntity responseEntity = httpResponse.getEntity();
 				        if(responseEntity != null) {
-				        	Loggers.SERVER.debug( EntityUtils.toString(responseEntity) );
+				        	LOG.debug( EntityUtils.toString(responseEntity) );
 			        	} else {
-			        		Loggers.SERVER.debug("Unable to parse response body. responseEntity is null");
+			        		LOG.debug("Unable to parse response body. responseEntity is null");
 			        	}
 			        } catch (IOException ex) {
-			        	Loggers.SERVER.debug("Unable to parse response body:" + ex.getMessage());
+			        	LOG.debug("Unable to parse response body:" + ex.getMessage());
 			        }
-			        Loggers.SERVER.debug("WebHookImpl::  --- End Server Response Body ---");
+			        LOG.debug("WebHookImpl::  --- End Server Response Body ---");
 		        }
 		    } finally {
 		        httppost.releaseConnection();
@@ -420,8 +422,8 @@ public class WebHookImpl implements WebHook {
 				this.getExecutionStats().setStatusReason(disabledReason);
 				return false;
 			} else {
-				if (Loggers.SERVER.isDebugEnabled()) {
-					Loggers.SERVER.debug("WebHookImpl: Filter match found: " + filter.getValue() + " (" + variable + ") matches using regex " + filter.getRegex() );
+				if (LOG.isDebugEnabled()) {
+					LOG.debug("WebHookImpl: Filter match found: " + filter.getValue() + " (" + variable + ") matches using regex " + filter.getRegex() );
 				}
 			}
 			

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/WebHookFactoryImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/WebHookFactoryImpl.java
@@ -3,6 +3,7 @@ package webhook.teamcity;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.intellij.openapi.diagnostic.Logger;
 import webhook.WebHook;
 import webhook.WebHookImpl;
 import webhook.WebHookProxyConfig;
@@ -14,6 +15,7 @@ import webhook.teamcity.settings.WebHookHeaderConfig;
 import webhook.teamcity.settings.WebHookMainSettings;
 
 public class WebHookFactoryImpl implements WebHookFactory {
+	private static final Logger LOG = Logger.getInstance(WebHookFactoryImpl.class.getName());
 
 	final WebHookMainSettings myMainSettings;
 	final WebHookAuthenticatorProvider myAuthenticatorProvider;
@@ -41,7 +43,7 @@ public class WebHookFactoryImpl implements WebHookFactory {
 				auth.setWebHookAuthConfig(webHookConfig.getAuthenticationConfig());
 				webHook.setAuthentication(auth);
 			} else {
-				Loggers.SERVER.warn("Could not enable authentication type '" + webHookConfig.getAuthenticationConfig().getType() + "' for URL " + webHookConfig.getUrl() );
+				LOG.warn("Could not enable authentication type '" + webHookConfig.getAuthenticationConfig().getType() + "' for URL " + webHookConfig.getUrl() );
 			}
 		}
 		

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/WebHookListener.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/WebHookListener.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -47,7 +48,7 @@ import webhook.teamcity.statistics.WebHooksStatisticsReportEventListener;
  * Listens for Server events and then triggers the execution of webhooks if configured.
  */
 public class WebHookListener extends BuildServerAdapter implements WebHooksStatisticsReportEventListener {
-
+	private static final Logger LOG = Logger.getInstance(WebHookListener.class.getName());
 	private static final String WEB_HOOK_LISTENER = "WebHookListener :: ";
 	private static final String ABOUT_TO_PROCESS_WEB_HOOKS_FOR = "About to process WebHooks for ";
 	private static final String AT_BUILD_STATE = " at buildState ";
@@ -77,17 +78,17 @@ public class WebHookListener extends BuildServerAdapter implements WebHooksStati
 		webHookStatisticsExecutor = statisticsExecutor;
 		webHookSettingsEventHandler = settingsEventHandler;
 
-		Loggers.SERVER.info(WEB_HOOK_LISTENER + "Starting");
+		LOG.info(WEB_HOOK_LISTENER + "Starting");
 	}
 
 	public void register(){
 		myBuildServer.addListener(this);
-		Loggers.SERVER.debug(WEB_HOOK_LISTENER + "Registering");
+		LOG.debug(WEB_HOOK_LISTENER + "Registering");
 	}
 
 	private void processBuildEvent(SBuild sBuild, BuildStateEnum state, Map<String, String> serviceMessageAttributes) {
 
-		Loggers.SERVER.debug(ABOUT_TO_PROCESS_WEB_HOOKS_FOR + sBuild.getProjectId() + AT_BUILD_STATE + state.getShortName());
+		LOG.debug(ABOUT_TO_PROCESS_WEB_HOOKS_FOR + sBuild.getProjectId() + AT_BUILD_STATE + state.getShortName());
 		for (WebHookConfig whc : getListOfEnabledWebHooks(state, sBuild.getProjectId())){
 			WebHook wh = webHookFactory.getWebHook(whc, myMainSettings.getProxyConfigForUrl(whc.getUrl()));
 			webHookExecutor.execute(wh, whc, sBuild, state, null, null, false, serviceMessageAttributes);
@@ -95,7 +96,7 @@ public class WebHookListener extends BuildServerAdapter implements WebHooksStati
 	}
 	private void processQueueEvent(SQueuedBuild sBuild, BuildStateEnum state, String user, String comment) {
 
-		Loggers.SERVER.debug(ABOUT_TO_PROCESS_WEB_HOOKS_FOR + sBuild.getBuildType().getProjectId() + AT_BUILD_STATE + state.getShortName());
+		LOG.debug(ABOUT_TO_PROCESS_WEB_HOOKS_FOR + sBuild.getBuildType().getProjectId() + AT_BUILD_STATE + state.getShortName());
 		for (WebHookConfig whc : getListOfEnabledWebHooks(state, sBuild.getBuildType().getProjectId())){
 			WebHook wh = webHookFactory.getWebHook(whc, myMainSettings.getProxyConfigForUrl(whc.getUrl()));
 			webHookExecutor.execute(wh, whc, sBuild, state, user, comment, false);
@@ -104,7 +105,7 @@ public class WebHookListener extends BuildServerAdapter implements WebHooksStati
 
 	private void processResponsibilityEvent(BuildStateEnum state, WebHookResponsibilityHolder responsibilityHolder) {
 
-		Loggers.SERVER.debug(ABOUT_TO_PROCESS_WEB_HOOKS_FOR + responsibilityHolder.getSProject().getProjectId() + AT_BUILD_STATE + state.getShortName());
+		LOG.debug(ABOUT_TO_PROCESS_WEB_HOOKS_FOR + responsibilityHolder.getSProject().getProjectId() + AT_BUILD_STATE + state.getShortName());
 		for (WebHookConfig whc : getListOfEnabledWebHooks(state, responsibilityHolder.getSProject().getProjectId())){
 			WebHook wh = webHookFactory.getWebHook(whc, myMainSettings.getProxyConfigForUrl(whc.getUrl()));
 			webHookExecutor.execute(wh, whc, state, responsibilityHolder, false);
@@ -113,7 +114,7 @@ public class WebHookListener extends BuildServerAdapter implements WebHooksStati
 
 	private void processPinEvent(SBuild sBuild, BuildStateEnum state, String user, String comment) {
 
-		Loggers.SERVER.debug(ABOUT_TO_PROCESS_WEB_HOOKS_FOR + sBuild.getBuildType().getProjectId() + AT_BUILD_STATE + state.getShortName());
+		LOG.debug(ABOUT_TO_PROCESS_WEB_HOOKS_FOR + sBuild.getBuildType().getProjectId() + AT_BUILD_STATE + state.getShortName());
 		for (WebHookConfig whc : getListOfEnabledWebHooks(state, sBuild.getBuildType().getProjectId())){
 			WebHook wh = webHookFactory.getWebHook(whc, myMainSettings.getProxyConfigForUrl(whc.getUrl()));
 			webHookExecutor.execute(wh, whc, sBuild, state, user, comment, false, Collections.emptyMap());
@@ -129,7 +130,7 @@ public class WebHookListener extends BuildServerAdapter implements WebHooksStati
 				}
 			}
 			for (SProject project : projects) {
-				Loggers.SERVER.debug(ABOUT_TO_PROCESS_WEB_HOOKS_FOR + project.getProjectId()+ AT_BUILD_STATE + state.getShortName());
+				LOG.debug(ABOUT_TO_PROCESS_WEB_HOOKS_FOR + project.getProjectId()+ AT_BUILD_STATE + state.getShortName());
 				for (WebHookConfig whc : getListOfEnabledWebHooks(state, project.getProjectId())){
 					WebHook wh = webHookFactory.getWebHook(whc, myMainSettings.getProxyConfigForUrl(whc.getUrl()));
 					webHookExecutor.execute(wh, whc, project, mutedOrUnmutedGroups, state, user, false);
@@ -155,8 +156,8 @@ public class WebHookListener extends BuildServerAdapter implements WebHooksStati
 				for (WebHookConfig whc : projSettings.getWebHooksConfigs()){
 					if (!whc.isEnabledForSubProjects().booleanValue() && !myProject.getProjectId().equals(project.getProjectId())){
 						// Sub-projects are disabled and we are a subproject.
-						if (Loggers.ACTIVITIES.isDebugEnabled()){
-							Loggers.ACTIVITIES.debug(this.getClass().getSimpleName() + ":getListOfEnabledWebHooks() "
+						if (LOG.isDebugEnabled()){
+							LOG.debug(this.getClass().getSimpleName() + ":getListOfEnabledWebHooks() "
 									+ ":: subprojects not enabled. myProject is: " + myProject.getProjectId() + ". webhook project is: " + project.getProjectId()+ " : " + whc.getUniqueKey());
 						}
 						continue;
@@ -167,21 +168,21 @@ public class WebHookListener extends BuildServerAdapter implements WebHooksStati
 							whc.setProjectExternalId(project.getExternalId());
 							whc.setProjectInternalId(project.getProjectId());
 							configs.add(whc);
-							Loggers.ACTIVITIES.debug("WebHookListener :: WebHook added to list of enabled webhooks. Enabled for " + state.toString() + ".  " + whc.getUrl() + " (" + whc.getPayloadTemplate() + ")" + " : " + whc.getUniqueKey());
+							LOG.debug("WebHookListener :: WebHook added to list of enabled webhooks. Enabled for " + state.toString() + ".  " + whc.getUrl() + " (" + whc.getPayloadTemplate() + ")" + " : " + whc.getUniqueKey());
 						} else {
-							Loggers.ACTIVITIES.warn("WebHookListener :: No registered Template: " + whc.getPayloadTemplate() + " for " + whc.getUniqueKey());
+							LOG.warn("WebHookListener :: No registered Template: " + whc.getPayloadTemplate() + " for " + whc.getUniqueKey());
 						}
 					} else if (whc.getEnabled().booleanValue() && !whc.isEnabledForBuildState(state)) {
-						if (Loggers.ACTIVITIES.isDebugEnabled()) {
-							Loggers.ACTIVITIES.debug("WebHookListener :: WebHook skipped. Not enabled for " + state.toString() + ".  " + whc.getUrl() + " (" + whc.getPayloadTemplate() + ")" + " : " + whc.getUniqueKey());
+						if (LOG.isDebugEnabled()) {
+							LOG.debug("WebHookListener :: WebHook skipped. Not enabled for " + state.toString() + ".  " + whc.getUrl() + " (" + whc.getPayloadTemplate() + ")" + " : " + whc.getUniqueKey());
 						}
 					} else {
-						Loggers.ACTIVITIES.debug(this.getClass().getSimpleName()
+						LOG.debug(this.getClass().getSimpleName()
 								+ ":processBuildEvent() :: WebHook disabled. Will not process " + whc.getUrl() + " (" + whc.getPayloadTemplate() + ")" + " : " + whc.getUniqueKey());
 					}
 				}
 			} else {
-				Loggers.ACTIVITIES.debug("WebHookListener :: WebHooks are disasbled for  " + projectId);
+				LOG.debug("WebHookListener :: WebHooks are disasbled for  " + projectId);
 			}
 		}
 		return configs;
@@ -371,49 +372,49 @@ public class WebHookListener extends BuildServerAdapter implements WebHooksStati
 	
 	@Override
 	public void projectRestored(String projectId) {
-	    Loggers.SERVER.debug("WebHookListener :: Handling projectRestored event for project: " + projectId);
+	    LOG.debug("WebHookListener :: Handling projectRestored event for project: " + projectId);
 	    this.webHookSettingsEventHandler.handleEvent(new WebHookSettingsEventImpl(WebHookSettingsEventType.PROJECT_CHANGED, projectId, null, null));
 	}
 	
 	@Override
 	public void projectMoved(SProject project, SProject originalParentProject) {
-	    Loggers.SERVER.debug("WebHookListener :: Handling projectMoved event for project: " + project.getProjectId());
+	    LOG.debug("WebHookListener :: Handling projectMoved event for project: " + project.getProjectId());
 	    this.webHookSettingsEventHandler.handleEvent(new WebHookSettingsEventImpl(WebHookSettingsEventType.PROJECT_CHANGED, project.getProjectId(), null, null));
 	}
 	
 	@Override
 	public void projectExternalIdChanged(SProject project, java.lang.String oldExternalId, java.lang.String newExternalId) {
-	    Loggers.SERVER.debug("WebHookListener :: Handling projectExternalIdChanged event for project: " + project.getProjectId());
+	    LOG.debug("WebHookListener :: Handling projectExternalIdChanged event for project: " + project.getProjectId());
 	    this.mySettings.handleProjectChangedEvent(new WebHookSettingsEventImpl(WebHookSettingsEventType.PROJECT_CHANGED, project.getProjectId(), null, null));
 	}
 	
 	@Override
 	public void projectPersisted(String projectId) {
-        Loggers.SERVER.debug("WebHookListener :: Handling projectPersisted event for project: " + projectId);
+        LOG.debug("WebHookListener :: Handling projectPersisted event for project: " + projectId);
         this.webHookSettingsEventHandler.handleEvent(new WebHookSettingsEventImpl(WebHookSettingsEventType.PROJECT_PERSISTED, projectId, null, null));
 	}
 	
 	@Override
 	public void projectRemoved(SProject project) {
-	    Loggers.SERVER.debug("WebHookListener :: Handling projectRemoved event for project: " + project.getProjectId());
+	    LOG.debug("WebHookListener :: Handling projectRemoved event for project: " + project.getProjectId());
 	    this.mySettings.removeAllWebHooksFromCacheForProject(project.getProjectId());
 	}
 	
 	@Override
 	public void projectArchived(String projectId) {
-	    Loggers.SERVER.debug("WebHookListener :: Handling projectArchived event for project: " + projectId);
+	    LOG.debug("WebHookListener :: Handling projectArchived event for project: " + projectId);
 	    this.mySettings.removeAllWebHooksFromCacheForProject(projectId);
 	}
 	
 	@Override
 	public void projectDearchived(String projectId) {
-	    Loggers.SERVER.debug("WebHookListener :: Handling projectDearchived event for project: " + projectId);
+	    LOG.debug("WebHookListener :: Handling projectDearchived event for project: " + projectId);
 	    this.webHookSettingsEventHandler.handleEvent(new WebHookSettingsEventImpl(WebHookSettingsEventType.PROJECT_CHANGED, projectId, null, null));
 	}
 	
 	@Override
 	public void buildTypeUnregistered(SBuildType buildType) {
-	    Loggers.SERVER.debug(String.format("WebHookListener :: Handling buildTypeUnregistered event for buildType: %s (%s)", buildType.getExternalId(), buildType.getInternalId()));
+	    LOG.debug(String.format("WebHookListener :: Handling buildTypeUnregistered event for buildType: %s (%s)", buildType.getExternalId(), buildType.getInternalId()));
 	    this.webHookSettingsEventHandler.handleEvent(new WebHookSettingsEventImpl(WebHookSettingsEventType.BUILD_TYPE_DELETED, buildType.getProjectId(), buildType.getBuildTypeId(), buildType));
 	}
 	

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/WebHookServiceMessageHandler.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/WebHookServiceMessageHandler.java
@@ -3,14 +3,15 @@ package webhook.teamcity;
 import java.util.Collections;
 import java.util.List;
 
-import jetbrains.buildServer.log.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.messages.BuildMessage1;
 import jetbrains.buildServer.messages.serviceMessages.ServiceMessage;
 import jetbrains.buildServer.messages.serviceMessages.ServiceMessageTranslator;
 import jetbrains.buildServer.serverSide.SRunningBuild;
 
 public class WebHookServiceMessageHandler implements ServiceMessageTranslator {
-	
+	private static final Logger LOG = Logger.getInstance(WebHookServiceMessageHandler.class.getName());
+
 	public static final String SERVICE_MESSAGE_NAME = "sendWebhook";
 	
 	private final WebHookListener myWebHookListener;
@@ -22,7 +23,7 @@ public class WebHookServiceMessageHandler implements ServiceMessageTranslator {
 	@Override
 	public List<BuildMessage1> translate(SRunningBuild runningBuild, BuildMessage1 originalMessage, ServiceMessage serviceMessage) {
 		myWebHookListener.serviceMessageReceived(runningBuild, serviceMessage.getAttributes());
-		Loggers.SERVER.debug("WebHookServiceMessageHandler :: WebHook service message event received for buildType : " + runningBuild.getBuildTypeExternalId() + " with build id "  + runningBuild.getBuildId());
+		LOG.debug("WebHookServiceMessageHandler :: WebHook service message event received for buildType : " + runningBuild.getBuildTypeExternalId() + " with build id "  + runningBuild.getBuildId());
 		
 		return Collections.singletonList(originalMessage);
 	}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/auth/WebHookAuthenticatorProvider.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/auth/WebHookAuthenticatorProvider.java
@@ -5,23 +5,24 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 
-import webhook.teamcity.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 
 public class WebHookAuthenticatorProvider {
+	private static final Logger LOG = Logger.getInstance(WebHookAuthenticatorProvider.class.getName());
 
 	HashMap<String, WebHookAuthenticatorFactory> types = new HashMap<>();
 
 	public WebHookAuthenticatorProvider(){
-		Loggers.SERVER.debug("WebHookAuthenticatorProvider :: Starting");
+		LOG.debug("WebHookAuthenticatorProvider :: Starting");
 	}
 
 	public void registerAuthType(WebHookAuthenticatorFactory authType){
-		Loggers.SERVER.info(this.getClass().getSimpleName() + " :: Registering authentication type "
+		LOG.info(this.getClass().getSimpleName() + " :: Registering authentication type "
 				+ authType.getName());
 		types.put(authType.getName(),authType);
-		Loggers.SERVER.debug(this.getClass().getSimpleName() + " :: Authenticator list is " + this.types.size() + " items long.");
+		LOG.debug(this.getClass().getSimpleName() + " :: Authenticator list is " + this.types.size() + " items long.");
 		for (String auth : this.types.keySet()){
-			Loggers.SERVER.debug(this.getClass().getSimpleName() + " :: Authenticator Name: " + auth);
+			LOG.debug(this.getClass().getSimpleName() + " :: Authenticator Name: " + auth);
 		}
 	}
 

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/executor/AbstractWebHookExecutor.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/executor/AbstractWebHookExecutor.java
@@ -3,13 +3,13 @@ package webhook.teamcity.executor;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.apache.http.HttpStatus;
 import org.apache.http.impl.EnglishReasonPhraseCatalog;
 
 import lombok.Getter;
 import webhook.WebHook;
 import webhook.teamcity.BuildStateEnum;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.WebHookContentBuilder;
 import webhook.teamcity.WebHookExecutionException;
 import webhook.teamcity.WebHookHttpExecutionException;
@@ -21,7 +21,8 @@ import webhook.teamcity.history.WebHookHistoryRepository;
 import webhook.teamcity.settings.WebHookConfig;
 
 public abstract class AbstractWebHookExecutor implements WebHookRunner {
-	
+	private static final Logger LOG = Logger.getInstance(AbstractWebHookExecutor.class.getName());
+
 	private static final String CLASS_NAME = "AbstractWebHookExecutor :: ";
 	protected final WebHookContentBuilder webHookContentBuilder;
 	protected final WebHookHistoryRepository webHookHistoryRepository;
@@ -58,20 +59,20 @@ public abstract class AbstractWebHookExecutor implements WebHookRunner {
 	
 	@Override
 	public void run() {
-		Loggers.SERVER.debug("AbstractWebHookExecutor :: Starting runner for webhook: " + webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey() + " : " + state.getShortName());
+		LOG.debug("AbstractWebHookExecutor :: Starting runner for webhook: " + webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey() + " : " + state.getShortName());
 		
 		try {
 			this.webhook = getWebHookContent();
 			
 			doPost(webhook, whc.getPayloadTemplate());
-			Loggers.ACTIVITIES.debug(CLASS_NAME + whc.getPayloadTemplate());
+			LOG.debug(CLASS_NAME + whc.getPayloadTemplate());
 			this.webHookHistoryItem = buildWebHookHistoryItem(null);
 			webHookHistoryRepository.addHistoryItem(this.webHookHistoryItem);
 
 		} catch (WebHookExecutionException ex){
 			webhook.getExecutionStats().setErrored(true);
 			webhook.getExecutionStats().setRequestCompleted(ex.getErrorCode(), ex.getMessage());
-			Loggers.SERVER.error(
+			LOG.error(
 					String.format("%s trackingId: %s :: projectId: %s :: webhookId: %s :: templateId: %s, errorCode: %s, errorMessage: %s", 
 							CLASS_NAME, 
 							webhook.getExecutionStats().getTrackingIdAsString(),
@@ -80,7 +81,7 @@ public abstract class AbstractWebHookExecutor implements WebHookRunner {
 							whc.getPayloadTemplate(),
 							ex.getErrorCode(),
 							ex.getMessage()));
-			Loggers.SERVER.debug(CLASS_NAME + webhook.getExecutionStats().getTrackingIdAsString() + " :: URL: " + webhook.getUrl(), ex);
+			LOG.debug(CLASS_NAME + webhook.getExecutionStats().getTrackingIdAsString() + " :: URL: " + webhook.getUrl(), ex);
 			this.webHookHistoryItem = buildWebHookHistoryItem(new WebHookErrorStatus(ex, ex.getMessage(), ex.getErrorCode()));
 			webHookHistoryRepository.addHistoryItem(webHookHistoryItem);
 			errorCallback(ex);
@@ -88,7 +89,7 @@ public abstract class AbstractWebHookExecutor implements WebHookRunner {
 		} catch (Exception ex){
 			webhook.getExecutionStats().setErrored(true);
 			webhook.getExecutionStats().setRequestCompleted(WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_ERROR_CODE, WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_MESSAGE + ex.getMessage());
-			Loggers.SERVER.error(
+			LOG.error(
 					String.format("%s trackingId: %s :: projectId: %s :: webhookId: %s :: templateId: %s, errorCode: %s, errorMessage: %s", 
 							CLASS_NAME, 
 							webhook.getExecutionStats().getTrackingIdAsString(),
@@ -96,14 +97,14 @@ public abstract class AbstractWebHookExecutor implements WebHookRunner {
 							whc.getUniqueKey(),
 							whc.getPayloadTemplate(),
 							WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_ERROR_CODE,
-							ex.getMessage()));			Loggers.SERVER.debug(CLASS_NAME + webhook.getExecutionStats().getTrackingIdAsString() + " :: URL: " + webhook.getUrl(), ex);
+							ex.getMessage()));			LOG.debug(CLASS_NAME + webhook.getExecutionStats().getTrackingIdAsString() + " :: URL: " + webhook.getUrl(), ex);
 			this.webHookHistoryItem = buildWebHookHistoryItem(new WebHookErrorStatus(ex, ex.getMessage(), 
 					WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_ERROR_CODE));
 			webHookHistoryRepository.addHistoryItem(this.webHookHistoryItem);
 			errorCallback(new RuntimeException(ex));
 		}
 		
-		Loggers.SERVER.debug("AbstractWebHookExecutor :: Finishing runner for webhook: " + webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey() + " : " + state.getShortName());
+		LOG.debug("AbstractWebHookExecutor :: Finishing runner for webhook: " + webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey() + " : " + state.getShortName());
 	}
 
 	
@@ -119,42 +120,42 @@ public abstract class AbstractWebHookExecutor implements WebHookRunner {
 		try {
 			if (Boolean.TRUE.equals(wh.isEnabled())){
 				wh.post();
-				Loggers.SERVER.info(CLASS_NAME + " :: WebHook triggered : " 
+				LOG.info(CLASS_NAME + " :: WebHook triggered : " 
 						+ determineSecureUrl(wh, shouldHideSecureData) + " using template " + payloadTemplate 
 						+ " returned " + wh.getStatus() 
 						+ " " + wh.getErrorReason());
-				if (Loggers.SERVER.isDebugEnabled()) {
+				if (LOG.isDebugEnabled()) {
 					if (shouldHideSecureData) {
-						Loggers.SERVER.debug(CLASS_NAME + ":doPost :: Hiding content payload because it may contain secured values. To log content to this log file uncheck 'Secure Values' in the WebHook edit dialog.");
+						LOG.debug(CLASS_NAME + ":doPost :: Hiding content payload because it may contain secured values. To log content to this log file uncheck 'Secure Values' in the WebHook edit dialog.");
 					} else if (wh.getExecutionStats().isSecureValueAccessed()) {
-						Loggers.SERVER.debug(CLASS_NAME + ":doPost :: Logging content payload even though it may contain secured values. To hide content in this log file check 'Secure Values' in the WebHook edit dialog.\n--- begin webhook payload ---\n" + wh.getPayload() + "\n--- end webhook payload ---");
-						Loggers.SERVER.debug("WebHook execution stats: " + wh.getExecutionStats().toString());
+						LOG.debug(CLASS_NAME + ":doPost :: Logging content payload even though it may contain secured values. To hide content in this log file check 'Secure Values' in the WebHook edit dialog.\n--- begin webhook payload ---\n" + wh.getPayload() + "\n--- end webhook payload ---");
+						LOG.debug("WebHook execution stats: " + wh.getExecutionStats().toString());
 					} else {
-						Loggers.SERVER.debug(CLASS_NAME + ":doPost :: Logging content payload because it contains no secured values.\n--- begin webhook payload ---\n" + wh.getPayload() + "\n--- end webhook payload ---");
+						LOG.debug(CLASS_NAME + ":doPost :: Logging content payload because it contains no secured values.\n--- begin webhook payload ---\n" + wh.getPayload() + "\n--- end webhook payload ---");
 					}
 				}
 				if (Boolean.TRUE.equals(wh.isErrored())){
-					Loggers.SERVER.error(wh.getErrorReason());
+					LOG.error(wh.getErrorReason());
 				}
 				if (wh.getStatus() == null) {
-					Loggers.SERVER.warn(CLASS_NAME + wh.getParam("projectId") + " WebHook (url: " + determineSecureUrl(wh, shouldHideSecureData) + " proxy: " + wh.getProxyHost() + ":" + wh.getProxyPort()+") returned HTTP status " + wh.getStatus().toString());
+					LOG.warn(CLASS_NAME + wh.getParam("projectId") + " WebHook (url: " + determineSecureUrl(wh, shouldHideSecureData) + " proxy: " + wh.getProxyHost() + ":" + wh.getProxyPort()+") returned HTTP status " + wh.getStatus().toString());
 					throw new WebHookHttpExecutionException("WebHook endpoint returned null response code");
 				} else if (wh.getStatus() < HttpStatus.SC_OK || wh.getStatus() >= HttpStatus.SC_MULTIPLE_CHOICES) {
-					Loggers.SERVER.warn(CLASS_NAME + wh.getParam("projectId") + " WebHook (url: " + determineSecureUrl(wh, shouldHideSecureData) + " proxy: " + wh.getProxyHost() + ":" + wh.getProxyPort()+") returned HTTP status " + wh.getStatus().toString());
+					LOG.warn(CLASS_NAME + wh.getParam("projectId") + " WebHook (url: " + determineSecureUrl(wh, shouldHideSecureData) + " proxy: " + wh.getProxyHost() + ":" + wh.getProxyPort()+") returned HTTP status " + wh.getStatus().toString());
 					throw new WebHookHttpResponseException("WebHook endpoint returned non-2xx response (" + EnglishReasonPhraseCatalog.INSTANCE.getReason(wh.getStatus(), null) +")", wh.getStatus());
 				}
 			} else {
-				if (Loggers.SERVER.isDebugEnabled()) Loggers.SERVER.debug("WebHook NOT triggered: " + wh.getDisabledReason() + " " +  wh.getParam("buildStatus") + " " + determineSecureUrl(wh, shouldHideSecureData));	
+				if (LOG.isDebugEnabled()) LOG.debug("WebHook NOT triggered: " + wh.getDisabledReason() + " " +  wh.getParam("buildStatus") + " " + determineSecureUrl(wh, shouldHideSecureData));	
 			}
 		} catch (FileNotFoundException e) {
-			Loggers.SERVER.warn(CLASS_NAME + ":doPost :: " 
+			LOG.warn(CLASS_NAME + ":doPost :: " 
 					+ "A FileNotFoundException occurred while attempting to execute WebHook (" + determineSecureUrl(wh, shouldHideSecureData) + "). See the following debug stacktrace");
-			Loggers.SERVER.debug(e);
+			LOG.debug(e);
 			throw new WebHookHttpExecutionException("A FileNotFoundException occurred while attempting to execute WebHook (" + determineSecureUrl(wh, shouldHideSecureData) + ")", e);
 		} catch (IOException e) {
-			Loggers.SERVER.warn(CLASS_NAME + ":doPost :: " 
+			LOG.warn(CLASS_NAME + ":doPost :: " 
 					+ "An IOException occurred while attempting to execute WebHook (" + determineSecureUrl(wh, shouldHideSecureData) + "). See the following debug stacktrace");
-			Loggers.SERVER.debug(e);
+			LOG.debug(e);
 			throw new WebHookHttpExecutionException("Error " + e.getMessage() + " occurred while attempting to execute WebHook.", e);
 		}
 		

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/executor/AbstractWebHookExecutor.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/executor/AbstractWebHookExecutor.java
@@ -97,7 +97,8 @@ public abstract class AbstractWebHookExecutor implements WebHookRunner {
 							whc.getUniqueKey(),
 							whc.getPayloadTemplate(),
 							WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_ERROR_CODE,
-							ex.getMessage()));			LOG.debug(CLASS_NAME + webhook.getExecutionStats().getTrackingIdAsString() + " :: URL: " + webhook.getUrl(), ex);
+							ex.getMessage()));
+			LOG.debug(CLASS_NAME + webhook.getExecutionStats().getTrackingIdAsString() + " :: URL: " + webhook.getUrl(), ex);
 			this.webHookHistoryItem = buildWebHookHistoryItem(new WebHookErrorStatus(ex, ex.getMessage(), 
 					WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_ERROR_CODE));
 			webHookHistoryRepository.addHistoryItem(this.webHookHistoryItem);

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/executor/WebHookSerialExecutorImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/executor/WebHookSerialExecutorImpl.java
@@ -3,6 +3,7 @@ package webhook.teamcity.executor;
 import java.util.Collection;
 import java.util.Map;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.serverSide.SProject;
 import jetbrains.buildServer.serverSide.SQueuedBuild;
@@ -12,25 +13,24 @@ import jetbrains.buildServer.users.SUser;
 import lombok.AllArgsConstructor;
 import webhook.WebHook;
 import webhook.teamcity.BuildStateEnum;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.settings.WebHookConfig;
 import webhook.teamcity.statistics.StatisticsReport;
 
 @AllArgsConstructor
 public class WebHookSerialExecutorImpl implements WebHookSerialExecutor, WebHookStatisticsExecutor {
-	
+	private static final Logger LOG = Logger.getInstance(WebHookSerialExecutorImpl.class.getName());
     private final WebHookRunnerFactory webHookRunnerFactory;
 
 	@Override
 	public void execute(WebHook webhook, WebHookConfig whc, SQueuedBuild sQueuedBuild, 
 						BuildStateEnum state, String user, String comment, boolean isTest) 
 	{
-		Loggers.SERVER.debug("WebHookSerialExecutorImpl :: About to start runner for webhook :: " + 
+		LOG.debug("WebHookSerialExecutorImpl :: About to start runner for webhook :: " + 
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey());
 
 		webHookRunnerFactory.getRunner(webhook, whc, sQueuedBuild, state, user, comment, isTest).run();
 		
-		Loggers.SERVER.debug("WebHookSerialExecutorImpl :: Finished runner for webhook :: " + 
+		LOG.debug("WebHookSerialExecutorImpl :: Finished runner for webhook :: " + 
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey());
 	}
 
@@ -38,12 +38,12 @@ public class WebHookSerialExecutorImpl implements WebHookSerialExecutor, WebHook
 	public void execute(WebHook webhook, WebHookConfig whc, BuildStateEnum state,
 			WebHookResponsibilityHolder responsibilityHolder, boolean isTest) {
 		
-		Loggers.SERVER.debug("WebHookSerialExecutorImpl :: About to start runner for webhook :: " + 
+		LOG.debug("WebHookSerialExecutorImpl :: About to start runner for webhook :: " + 
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey());
 
 		webHookRunnerFactory.getRunner(webhook, whc, state, responsibilityHolder, isTest).run();
 		
-		Loggers.SERVER.debug("WebHookSerialExecutorImpl :: Finished runner for webhook :: " + 
+		LOG.debug("WebHookSerialExecutorImpl :: Finished runner for webhook :: " + 
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey());
 	}
 
@@ -51,36 +51,36 @@ public class WebHookSerialExecutorImpl implements WebHookSerialExecutor, WebHook
 	public void execute(WebHook webhook, WebHookConfig whc, SBuild sBuild, BuildStateEnum state, String username,
 			String comment, boolean isTest, Map<String,String> extraAttributes) 
 	{
-		Loggers.SERVER.debug("WebHookSerialExecutorImpl :: About to start runner for webhook :: " + 
+		LOG.debug("WebHookSerialExecutorImpl :: About to start runner for webhook :: " + 
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey());
 
 		webHookRunnerFactory.getRunner(webhook, whc, sBuild, state, username, comment, isTest, extraAttributes).run();
 		
-		Loggers.SERVER.debug("WebHookSerialExecutorImpl :: Finished runner for webhook :: " + 
+		LOG.debug("WebHookSerialExecutorImpl :: Finished runner for webhook :: " + 
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey());
 	}
 
 	@Override
 	public void execute(WebHook webhook, WebHookConfig whc, BuildStateEnum state, 
 			StatisticsReport report, SProject rootProject, boolean isTest) {
-		Loggers.SERVER.debug("WebHookSerialExecutorImpl :: About to start runner for webhook :: " + 
+		LOG.debug("WebHookSerialExecutorImpl :: About to start runner for webhook :: " + 
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey());
 
 		webHookRunnerFactory.getRunner(webhook, whc, state, report, rootProject, isTest).run();
 		
-		Loggers.SERVER.debug("WebHookSerialExecutorImpl :: Finished runner for webhook :: " + 
+		LOG.debug("WebHookSerialExecutorImpl :: Finished runner for webhook :: " + 
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey());
 	}
 
     @Override
     public void execute(WebHook webhook, WebHookConfig whc, SProject sProject,
             Map<MuteInfo, Collection<STest>> mutedOrUnmutedGroups, BuildStateEnum state, SUser user, boolean isTest) {
-        Loggers.SERVER.debug("WebHookSerialExecutorImpl :: About to start runner for webhook :: " + 
+        LOG.debug("WebHookSerialExecutorImpl :: About to start runner for webhook :: " + 
                 webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey());
 
         webHookRunnerFactory.getRunner(webhook, whc, sProject, state, mutedOrUnmutedGroups, isTest).run();
         
-        Loggers.SERVER.debug("WebHookSerialExecutorImpl :: Finished runner for webhook :: " + 
+        LOG.debug("WebHookSerialExecutorImpl :: Finished runner for webhook :: " + 
                 webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey());    }
 	
 }

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/executor/WebHookThreadingExecutorFactoryImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/executor/WebHookThreadingExecutorFactoryImpl.java
@@ -2,16 +2,17 @@ package webhook.teamcity.executor;
 
 import java.util.concurrent.ExecutorService;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.executors.ExecutorServices;
 import jetbrains.buildServer.util.executors.ExecutorsFactory;
 import lombok.RequiredArgsConstructor;
 import webhook.teamcity.DeferrableService;
 import webhook.teamcity.DeferrableServiceManager;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.settings.WebHookMainSettings;
 
 @RequiredArgsConstructor
 public class WebHookThreadingExecutorFactoryImpl implements WebHookThreadingExecutorFactory, DeferrableService {
+	private static final Logger LOG = Logger.getInstance(WebHookThreadingExecutorFactoryImpl.class.getName());
 
 	private final ExecutorServices executorServices;
 	private final WebHookMainSettings myMainSettings;
@@ -39,7 +40,7 @@ public class WebHookThreadingExecutorFactoryImpl implements WebHookThreadingExec
 							this.myMainSettings.getWebHookMainConfig().getMinPoolSize(),
 							this.myMainSettings.getWebHookMainConfig().getMaxPoolSize(),
 							this.myMainSettings.getWebHookMainConfig().getQueueSize());
-					Loggers.SERVER.info(String.format(
+					LOG.info(String.format(
 							"WebHookThreadingExecutorFactoryImpl :: Creating WebHook Dedicated ExecutorService minPoolSize=%s, maxPoolSize=%s, queueSize=%s",
 							this.myMainSettings.getWebHookMainConfig().getMinPoolSize(),
 							this.myMainSettings.getWebHookMainConfig().getMaxPoolSize(),
@@ -52,20 +53,20 @@ public class WebHookThreadingExecutorFactoryImpl implements WebHookThreadingExec
 
 	@Override
 	public void requestDeferredRegistration() {
-		Loggers.SERVER.info("WebHookThreadingExecutorFactoryImpl :: Registering as a deferrable service");
+		LOG.info("WebHookThreadingExecutorFactoryImpl :: Registering as a deferrable service");
 		deferrableServiceManager.registerService(this);
 	}
 
 	@Override
 	public void register() {
-		Loggers.SERVER.info("WebHookThreadingExecutorFactoryImpl :: Initialising WebHook ExecutorService");
+		LOG.info("WebHookThreadingExecutorFactoryImpl :: Initialising WebHook ExecutorService");
 		getInstanceUsingDoubleLocking();
 	}
 
 	@Override
 	public void unregister() {
 		if (this.executorService != null) {
-			Loggers.SERVER.info("WebHookThreadingExecutorFactoryImpl :: Shutting down WebHook ExecutorService");
+			LOG.info("WebHookThreadingExecutorFactoryImpl :: Shutting down WebHook ExecutorService");
 			this.executorService.shutdownNow();
 		}
 	}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/executor/WebHookThreadingExecutorImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/executor/WebHookThreadingExecutorImpl.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.serverSide.SProject;
 import jetbrains.buildServer.serverSide.SQueuedBuild;
@@ -13,7 +14,6 @@ import jetbrains.buildServer.users.SUser;
 import lombok.AllArgsConstructor;
 import webhook.WebHook;
 import webhook.teamcity.BuildStateEnum;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.WebHookExecutionException;
 import webhook.teamcity.history.WebHookHistoryItem;
 import webhook.teamcity.history.WebHookHistoryItem.WebHookErrorStatus;
@@ -22,6 +22,7 @@ import webhook.teamcity.settings.WebHookConfig;
 
 @AllArgsConstructor
 public class WebHookThreadingExecutorImpl implements WebHookThreadingExecutor {
+	private static final Logger LOG = Logger.getInstance(WebHookThreadingExecutorImpl.class.getName());
 
 	private static final String CLASS_NAME = "WebHookThreadingExecutorImpl :: ";
 
@@ -32,7 +33,7 @@ public class WebHookThreadingExecutorImpl implements WebHookThreadingExecutor {
 	@Override
 	public void execute(WebHook webhook, WebHookConfig whc, SQueuedBuild sQueuedBuild,
 			BuildStateEnum state, String user, String comment, boolean isTest) {
-		Loggers.SERVER.debug("WebHookThreadingExecutorImpl :: About to schedule runner for webhook :: " +
+		LOG.debug("WebHookThreadingExecutorImpl :: About to schedule runner for webhook :: " +
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey()+ " : " + state.getShortName());
 
 		WebHookRunner runner = webHookRunnerFactory.getRunner(webhook, whc, sQueuedBuild, state, user, comment, isTest);
@@ -44,7 +45,7 @@ public class WebHookThreadingExecutorImpl implements WebHookThreadingExecutor {
 			handleException(webhook, whc, runner, state, ex, WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_ERROR_CODE, WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_MESSAGE);
 		}
 
-		Loggers.SERVER.debug("WebHookThreadingExecutorImpl :: Finished scheduling runner for webhook :: " +
+		LOG.debug("WebHookThreadingExecutorImpl :: Finished scheduling runner for webhook :: " +
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey()+ " : " + state.getShortName());
 	}
 
@@ -52,7 +53,7 @@ public class WebHookThreadingExecutorImpl implements WebHookThreadingExecutor {
 	public void execute(WebHook webhook, WebHookConfig whc, BuildStateEnum state,
 			WebHookResponsibilityHolder responsibilityHolder,
 			boolean isTest) {
-		Loggers.SERVER.debug("WebHookThreadingExecutorImpl :: About to schedule runner for webhook :: " +
+		LOG.debug("WebHookThreadingExecutorImpl :: About to schedule runner for webhook :: " +
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey()+ " : " + state.getShortName());
 
 		WebHookRunner runner = webHookRunnerFactory.getRunner(webhook, whc, state, responsibilityHolder, isTest);
@@ -64,7 +65,7 @@ public class WebHookThreadingExecutorImpl implements WebHookThreadingExecutor {
 			handleException(webhook, whc, runner, state, ex, WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_ERROR_CODE, WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_MESSAGE);
 		}
 
-		Loggers.SERVER.debug("WebHookThreadingExecutorImpl :: Finished scheduling runner for webhook :: " +
+		LOG.debug("WebHookThreadingExecutorImpl :: Finished scheduling runner for webhook :: " +
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey() + " : " + state.getShortName());
 	}
 
@@ -72,7 +73,7 @@ public class WebHookThreadingExecutorImpl implements WebHookThreadingExecutor {
 	public void execute(WebHook webhook, WebHookConfig whc, SBuild sBuild, BuildStateEnum state, String user,
 			String comment,
 			boolean isTest, Map<String, String> extraAttributes) {
-		Loggers.SERVER.debug("WebHookThreadingExecutorImpl :: About to schedule runner for webhook :: " +
+		LOG.debug("WebHookThreadingExecutorImpl :: About to schedule runner for webhook :: " +
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey()+ " : " + state.getShortName());
 
 		WebHookRunner runner = webHookRunnerFactory.getRunner(webhook, whc, sBuild, state, user, comment, isTest,
@@ -85,7 +86,7 @@ public class WebHookThreadingExecutorImpl implements WebHookThreadingExecutor {
 			handleException(webhook, whc, runner, state, ex, WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_ERROR_CODE, WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_MESSAGE);
 		}
 
-		Loggers.SERVER.debug("WebHookThreadingExecutorImpl :: Finished scheduling runner for webhook :: " +
+		LOG.debug("WebHookThreadingExecutorImpl :: Finished scheduling runner for webhook :: " +
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey() + " : " + state.getShortName());
 
 	}
@@ -94,7 +95,7 @@ public class WebHookThreadingExecutorImpl implements WebHookThreadingExecutor {
 	public void execute(WebHook webhook, WebHookConfig whc, SProject sProject,
 			Map<MuteInfo, Collection<STest>> mutedOrUnmutedGroups, BuildStateEnum state, SUser user, boolean isTest) {
 
-		Loggers.SERVER.debug("WebHookSerialExecutorImpl :: About to start runner for webhook :: " +
+		LOG.debug("WebHookSerialExecutorImpl :: About to start runner for webhook :: " +
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey()+ " : " + state.getShortName());
 
 		WebHookRunner runner = webHookRunnerFactory.getRunner(webhook, whc, sProject, state, mutedOrUnmutedGroups,
@@ -107,7 +108,7 @@ public class WebHookThreadingExecutorImpl implements WebHookThreadingExecutor {
 			handleException(webhook, whc, runner, state, ex, WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_ERROR_CODE, WebHookExecutionException.WEBHOOK_UNEXPECTED_EXCEPTION_MESSAGE);
 		}
 
-		Loggers.SERVER.debug("WebHookSerialExecutorImpl :: Finished runner for webhook :: " +
+		LOG.debug("WebHookSerialExecutorImpl :: Finished runner for webhook :: " +
 				webhook.getExecutionStats().getTrackingIdAsString() + " : " + whc.getUniqueKey()+ " : " + state.getShortName());
 
 	}
@@ -118,7 +119,7 @@ public class WebHookThreadingExecutorImpl implements WebHookThreadingExecutor {
 			webhook.getExecutionStats().setRequestCompleted(
 					webhookErrorCode,
 					webhookErrorMessage + ex.getMessage());
-			Loggers.SERVER.error(
+			LOG.error(
 					String.format(
 							"%s trackingId: %s :: projectId: %s :: webhookId: %s :: templateId: %s, errorCode: %s, errorMessage: %s",
 							CLASS_NAME,
@@ -128,7 +129,7 @@ public class WebHookThreadingExecutorImpl implements WebHookThreadingExecutor {
 							whc.getPayloadTemplate(),
 							webhookErrorCode,
 							ex.getMessage()));
-			Loggers.SERVER.debug(
+			LOG.debug(
 					CLASS_NAME + webhook.getExecutionStats().getTrackingIdAsString() + " :: URL: " + webhook.getUrl(), ex);
 			WebHookHistoryItem webHookHistoryItem = runner
 					.buildWebHookHistoryItem(new WebHookErrorStatus(ex, ex.getMessage(),

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/history/WebHookHistoryRepositoryImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/history/WebHookHistoryRepositoryImpl.java
@@ -13,12 +13,12 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.joda.time.LocalDate;
 
-import webhook.teamcity.Loggers;
-
 public class WebHookHistoryRepositoryImpl implements WebHookHistoryRepository {
-	
+	private static final Logger LOG = Logger.getInstance(WebHookHistoryRepositoryImpl.class.getName());
+
 	Map<UUID,WebHookHistoryItem> webHookHistoryItems = Collections.synchronizedMap(new MaxSizeHashMap<UUID,WebHookHistoryItem>(10000)); 
 	Comparator<WebHookHistoryItem> chronComparator = new WebHookHistoryRepositoryDateSortingCompator(SortDirection.ASC);
 	Comparator<WebHookHistoryItem> reverseChronComparator = new WebHookHistoryRepositoryDateSortingCompator(SortDirection.DESC);
@@ -245,7 +245,7 @@ public class WebHookHistoryRepositoryImpl implements WebHookHistoryRepository {
 	
 	private List<WebHookHistoryItem> findAllItemsSince(Set<LocalDate> dateRange) {
 		List<WebHookHistoryItem> erroredItemsSince = new ArrayList<>();
-		Loggers.SERVER.debug("WebHookHistoryRepositoryImpl :: Waiting on synchronized block for webhookHistoryItems");
+		LOG.debug("WebHookHistoryRepositoryImpl :: Waiting on synchronized block for webhookHistoryItems");
 		synchronized (webHookHistoryItems) {
 			for (WebHookHistoryItem item : this.webHookHistoryItems.values()) {
 				if (dateRange.contains(item.getTimestamp().toLocalDate())) {
@@ -253,7 +253,7 @@ public class WebHookHistoryRepositoryImpl implements WebHookHistoryRepository {
 				}
 			}
 		}
-		Loggers.SERVER.debug("WebHookHistoryRepositoryImpl :: Exited synchronized block for webhookHistoryItems");
+		LOG.debug("WebHookHistoryRepositoryImpl :: Exited synchronized block for webhookHistoryItems");
 		return erroredItemsSince;
 	}
 
@@ -263,7 +263,7 @@ public class WebHookHistoryRepositoryImpl implements WebHookHistoryRepository {
 		for (int i = numberOfDays; i > 0 ; i--) {
 			days.add(untilDate.minusDays(i));
 		}
-		Loggers.SERVER.debug(String.format("WebHookHistoryRepositoryImpl :: Resolving requested dates to: [%s]", days.toString()));
+		LOG.debug(String.format("WebHookHistoryRepositoryImpl :: Resolving requested dates to: [%s]", days.toString()));
 		return days;
 	}
 

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookPayloadManager.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookPayloadManager.java
@@ -7,11 +7,12 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.SBuildServer;
-import webhook.teamcity.Loggers;
 
 public class WebHookPayloadManager {
-	
+	private static final Logger LOG = Logger.getInstance(WebHookPayloadManager.class.getName());
+
 	HashMap<String, WebHookPayload> formats = new HashMap<>();
 	Comparator<WebHookPayload> rankComparator = new WebHookPayloadRankingComparator();
 	List<WebHookPayload> orderedFormatCollection = new ArrayList<>();
@@ -19,20 +20,20 @@ public class WebHookPayloadManager {
 	
 	public WebHookPayloadManager(SBuildServer server){
 		this.server = server;
-		Loggers.SERVER.debug("WebHookPayloadManager :: Starting");
+		LOG.debug("WebHookPayloadManager :: Starting");
 	}
 	
 	public void registerPayloadFormat(WebHookPayload payloadFormat){
-		Loggers.SERVER.info(this.getClass().getSimpleName() + " :: Registering payload " 
+		LOG.info(this.getClass().getSimpleName() + " :: Registering payload " 
 				+ payloadFormat.getFormatShortName() 
 				+ " with rank of " + payloadFormat.getRank());
 		formats.put(payloadFormat.getFormatShortName().toLowerCase(),payloadFormat);
 		this.orderedFormatCollection.add(payloadFormat);
 		
 		Collections.sort(this.orderedFormatCollection, rankComparator);
-		Loggers.SERVER.debug(this.getClass().getSimpleName() + " :: Payloads list is " + this.orderedFormatCollection.size() + " items long. Payloads are ranked in the following order..");
+		LOG.debug(this.getClass().getSimpleName() + " :: Payloads list is " + this.orderedFormatCollection.size() + " items long. Payloads are ranked in the following order..");
 		for (WebHookPayload pl : this.orderedFormatCollection){
-			Loggers.SERVER.debug(this.getClass().getSimpleName() + " :: Payload Name: " + pl.getFormatShortName() + " Rank: " + pl.getRank());
+			LOG.debug(this.getClass().getSimpleName() + " :: Payload Name: " + pl.getFormatShortName() + " Rank: " + pl.getRank());
 		}
 	}
 

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookTemplateFileChangeHandler.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookTemplateFileChangeHandler.java
@@ -5,9 +5,9 @@ import java.io.FileNotFoundException;
 
 import javax.xml.bind.JAXBException;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.configuration.ChangeListener;
 import jetbrains.buildServer.configuration.FileWatcher;
-import jetbrains.buildServer.log.Loggers;
 import jetbrains.buildServer.serverSide.ServerPaths;
 import webhook.teamcity.DeferrableService;
 import webhook.teamcity.DeferrableServiceManager;
@@ -16,6 +16,7 @@ import webhook.teamcity.settings.entity.WebHookTemplateJaxHelper;
 import webhook.teamcity.settings.entity.WebHookTemplates;
 
 public class WebHookTemplateFileChangeHandler implements ChangeListener, WebHookConfigChangeHandler, DeferrableService {
+	private static final Logger LOG = Logger.getInstance(WebHookTemplateFileChangeHandler.class.getName());
 
 	final WebHookTemplateManager webHookTemplateManager;
 	final WebHookPayloadManager webHookPayloadManager;
@@ -33,18 +34,18 @@ public class WebHookTemplateFileChangeHandler implements ChangeListener, WebHook
 		this.webHookTemplateJaxHelper = webHookTemplateJaxHelper;
 		this.serverPaths = serverPaths;
 		this.deferrableServiceManager = deferrableServiceManager;
-		Loggers.SERVER.debug("WebHookTemplateFileChangeHandler :: Starting");
+		LOG.debug("WebHookTemplateFileChangeHandler :: Starting");
 	}
 	
 	@Override
 	public void requestDeferredRegistration() {
-		Loggers.SERVER.info("WebHookTemplateFileChangeHandler :: Registering as a deferrable service");
+		LOG.info("WebHookTemplateFileChangeHandler :: Registering as a deferrable service");
 		deferrableServiceManager.registerService(this);
 	}
 	
 	@Override
 	public void register(){
-		Loggers.SERVER.debug("WebHookTemplateFileChangeHandler :: Registering");
+		LOG.debug("WebHookTemplateFileChangeHandler :: Registering");
 		this.configFile = new File(this.serverPaths.getConfigDir() + File.separator + "webhook-templates.xml");
 		
 		this.fw = new FileWatcher(configFile);
@@ -55,7 +56,7 @@ public class WebHookTemplateFileChangeHandler implements ChangeListener, WebHook
 		this.fw.registerListener(this);
 		this.fw.start();
 		
-		Loggers.SERVER.info("WebHookTemplateFileChangeHandler :: Watching for changes to file: " + this.configFile.getPath());
+		LOG.info("WebHookTemplateFileChangeHandler :: Watching for changes to file: " + this.configFile.getPath());
 	}
 	
 	@Override
@@ -65,8 +66,8 @@ public class WebHookTemplateFileChangeHandler implements ChangeListener, WebHook
 
 	@Override
 	public void changeOccured(String requestor) {
-		Loggers.SERVER.info("WebHookTemplateFileChangeHandler :: Handling change to file: " + this.configFile.getPath() + " requested by " + requestor);
-		Loggers.SERVER.debug("WebHookTemplateFileChangeHandler :: My instance is: " + this.toString() + " :: WebHookTemplateManager: " + webHookTemplateManager.toString());
+		LOG.info("WebHookTemplateFileChangeHandler :: Handling change to file: " + this.configFile.getPath() + " requested by " + requestor);
+		LOG.debug("WebHookTemplateFileChangeHandler :: My instance is: " + this.toString() + " :: WebHookTemplateManager: " + webHookTemplateManager.toString());
 		this.handleConfigFileChange();
 
 	}
@@ -77,11 +78,11 @@ public class WebHookTemplateFileChangeHandler implements ChangeListener, WebHook
 			WebHookTemplates templatesList =  webHookTemplateJaxHelper.readTemplates(configFile.getPath());
 			this.webHookTemplateManager.registerAllXmlTemplates(templatesList);
 		} catch (FileNotFoundException e) {
-			Loggers.SERVER.warn("WebHookTemplateFileChangeHandler :: Exception occurred attempting to reload WebHookTemplates. File not found: " + this.configFile.getPath());
-			Loggers.SERVER.debug(e);
+			LOG.warn("WebHookTemplateFileChangeHandler :: Exception occurred attempting to reload WebHookTemplates. File not found: " + this.configFile.getPath());
+			LOG.debug(e);
 		} catch (JAXBException e) {
-			Loggers.SERVER.warn("WebHookTemplateFileChangeHandler :: Exception occurred attempting to reload WebHookTemplates. Could not parse: " + this.configFile.getPath());
-			Loggers.SERVER.debug(e);
+			LOG.warn("WebHookTemplateFileChangeHandler :: Exception occurred attempting to reload WebHookTemplates. Could not parse: " + this.configFile.getPath());
+			LOG.debug(e);
 		}
 		
 	}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookTemplateManager.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/WebHookTemplateManager.java
@@ -11,10 +11,10 @@ import java.util.Objects;
 
 import javax.xml.bind.JAXBException;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.SProject;
 import jetbrains.buildServer.serverSide.auth.AccessDeniedException;
 import webhook.Constants;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.ProbableJaxbJarConflictErrorException;
 import webhook.teamcity.ProjectIdResolver;
 import webhook.teamcity.payload.template.WebHookTemplateFromXml;
@@ -25,7 +25,8 @@ import webhook.teamcity.settings.entity.WebHookTemplateJaxHelper;
 import webhook.teamcity.settings.entity.WebHookTemplates;
 
 public class WebHookTemplateManager {
-	
+	private static final Logger LOG = Logger.getInstance(WebHookTemplateManager.class.getName());
+
 	private static final String TEMPLATES_ARE_RANKED_IN_THE_FOLLOWING_ORDER = " items long. Templates are ranked in the following order..";
 	private static final String TEMPLATE_NAME = " :: Template Name: ";
 	private static final String TEMPLATES_LIST_IS = " :: Templates list is ";
@@ -46,25 +47,25 @@ public class WebHookTemplateManager {
 		this.webHookPayloadManager = webHookPayloadManager;
 		this.webHookTemplateJaxHelper = webHookTemplateJaxHelper;
 		this.projectIdResolver = projectIdResolver;
-		Loggers.SERVER.debug("WebHookTemplateManager :: Starting (" + toString() + ")");
+		LOG.debug("WebHookTemplateManager :: Starting (" + toString() + ")");
 	}
 	
 	public void registerTemplateFormatFromSpring(WebHookPayloadTemplate payloadTemplate){
 		synchronized (orderedTemplateCollection) {
-			Loggers.SERVER.info(this.getClass().getSimpleName() + " :: Registering Spring template " 
+			LOG.info(this.getClass().getSimpleName() + " :: Registering Spring template " 
 					+ payloadTemplate.getTemplateDescription() + " (" + payloadTemplate.getTemplateId() + ")"
 					+ " with rank of " + payloadTemplate.getRank());
 			springTemplates.put(payloadTemplate.getTemplateId(),payloadTemplate);
 			rebuildOrderedListOfTemplates();
-			Loggers.SERVER.debug(this.getClass().getSimpleName() + TEMPLATES_LIST_IS + this.orderedTemplateCollection.size() + TEMPLATES_ARE_RANKED_IN_THE_FOLLOWING_ORDER);
+			LOG.debug(this.getClass().getSimpleName() + TEMPLATES_LIST_IS + this.orderedTemplateCollection.size() + TEMPLATES_ARE_RANKED_IN_THE_FOLLOWING_ORDER);
 			for (WebHookPayloadTemplate pl : this.orderedTemplateCollection){
-				Loggers.SERVER.debug(this.getClass().getSimpleName() + TEMPLATE_NAME + pl.getTemplateDescription() + " (" + pl.getTemplateId() + ")" + " Rank: " + pl.getRank());
+				LOG.debug(this.getClass().getSimpleName() + TEMPLATE_NAME + pl.getTemplateDescription() + " (" + pl.getTemplateId() + ")" + " Rank: " + pl.getRank());
 			}
 		}
 	}
 	
 	private void registerTemplateFormatFromXmlEntityUnsyncd(WebHookTemplateEntity payloadTemplate){
-		Loggers.SERVER.info(this.getClass().getSimpleName() + " :: Registering XML template " 
+		LOG.info(this.getClass().getSimpleName() + " :: Registering XML template " 
 				+ payloadTemplate.getId() 
 				+ " with rank of " + payloadTemplate.getRank());
 		// Set template as belonging to _Root if no associated project id found for this template.
@@ -81,9 +82,9 @@ public class WebHookTemplateManager {
 		synchronized (orderedTemplateCollection) {
 			registerTemplateFormatFromXmlEntityUnsyncd(payloadTemplate);	
 			rebuildOrderedListOfTemplates();
-			Loggers.SERVER.debug(this.getClass().getSimpleName() + TEMPLATES_LIST_IS + this.orderedTemplateCollection.size() + TEMPLATES_ARE_RANKED_IN_THE_FOLLOWING_ORDER);
+			LOG.debug(this.getClass().getSimpleName() + TEMPLATES_LIST_IS + this.orderedTemplateCollection.size() + TEMPLATES_ARE_RANKED_IN_THE_FOLLOWING_ORDER);
 			for (WebHookPayloadTemplate pl : this.orderedTemplateCollection){
-				Loggers.SERVER.debug(this.getClass().getSimpleName() + TEMPLATE_NAME + pl.getTemplateId() + " Rank: " + pl.getRank());
+				LOG.debug(this.getClass().getSimpleName() + TEMPLATE_NAME + pl.getTemplateId() + " Rank: " + pl.getRank());
 			}
 		}
 	}
@@ -93,20 +94,20 @@ public class WebHookTemplateManager {
 		synchronized (orderedTemplateCollection) {
 			registerTemplateFormatFromXmlEntityUnsyncd(payloadTemplate);	
 			rebuildOrderedListOfTemplates();
-			Loggers.SERVER.debug(this.getClass().getSimpleName() + TEMPLATES_LIST_IS + this.orderedTemplateCollection.size() + TEMPLATES_ARE_RANKED_IN_THE_FOLLOWING_ORDER);
+			LOG.debug(this.getClass().getSimpleName() + TEMPLATES_LIST_IS + this.orderedTemplateCollection.size() + TEMPLATES_ARE_RANKED_IN_THE_FOLLOWING_ORDER);
 			for (WebHookPayloadTemplate pl : this.orderedTemplateCollection){
-				Loggers.SERVER.debug(this.getClass().getSimpleName() + TEMPLATE_NAME + pl.getTemplateId() + " Rank: " + pl.getRank());
+				LOG.debug(this.getClass().getSimpleName() + TEMPLATE_NAME + pl.getTemplateId() + " Rank: " + pl.getRank());
 			}
 		}
 	}
 	
 	private void unregisterAllXmlConfigTemplates(){
-			Loggers.SERVER.debug(this.getClass().getSimpleName() + " :: un-registering all XML config templates.");
+			LOG.debug(this.getClass().getSimpleName() + " :: un-registering all XML config templates.");
 			xmlConfigTemplates.clear();
 			rebuildOrderedListOfTemplates();
-			Loggers.SERVER.debug(this.getClass().getSimpleName() + TEMPLATES_LIST_IS + this.orderedTemplateCollection.size() + TEMPLATES_ARE_RANKED_IN_THE_FOLLOWING_ORDER);
+			LOG.debug(this.getClass().getSimpleName() + TEMPLATES_LIST_IS + this.orderedTemplateCollection.size() + TEMPLATES_ARE_RANKED_IN_THE_FOLLOWING_ORDER);
 			for (WebHookPayloadTemplate pl : this.orderedTemplateCollection){
-				Loggers.SERVER.debug(this.getClass().getSimpleName() + TEMPLATE_NAME + pl.getTemplateId() + " Rank: " + pl.getRank());
+				LOG.debug(this.getClass().getSimpleName() + TEMPLATE_NAME + pl.getTemplateId() + " Rank: " + pl.getRank());
 			}
 	}
 	
@@ -123,7 +124,7 @@ public class WebHookTemplateManager {
 				if (jaxbException.getMessage().startsWith("ClassCastException")) {
 					throw new ProbableJaxbJarConflictErrorException(jaxbException);
 				}
-				Loggers.SERVER.debug(jaxbException);
+				LOG.debug(jaxbException);
 				return false;
 			} 
 		}
@@ -307,12 +308,12 @@ public class WebHookTemplateManager {
 				xmlConfigTemplates.remove(name);
 				rebuildOrderedListOfTemplates();
 				
-				Loggers.SERVER.info(this.getClass().getSimpleName() + " :: Deleting XML template " 
+				LOG.info(this.getClass().getSimpleName() + " :: Deleting XML template " 
 						+ name);
 				rebuildOrderedListOfTemplates();
-				Loggers.SERVER.debug(this.getClass().getSimpleName() + TEMPLATES_LIST_IS + this.orderedTemplateCollection.size() + TEMPLATES_ARE_RANKED_IN_THE_FOLLOWING_ORDER);
+				LOG.debug(this.getClass().getSimpleName() + TEMPLATES_LIST_IS + this.orderedTemplateCollection.size() + TEMPLATES_ARE_RANKED_IN_THE_FOLLOWING_ORDER);
 				for (WebHookPayloadTemplate pl : this.orderedTemplateCollection){
-					Loggers.SERVER.debug(this.getClass().getSimpleName() + TEMPLATE_NAME + pl.getTemplateId() + " Rank: " + pl.getRank());
+					LOG.debug(this.getClass().getSimpleName() + TEMPLATE_NAME + pl.getTemplateId() + " Rank: " + pl.getRank());
 				}			
 				return true;
 			}
@@ -327,9 +328,9 @@ public class WebHookTemplateManager {
 				this.registerTemplateFormatFromXmlEntityUnsyncd(template);
 			}
 			rebuildOrderedListOfTemplates();
-			Loggers.SERVER.debug(this.getClass().getSimpleName() + TEMPLATES_LIST_IS + this.orderedTemplateCollection.size() + TEMPLATES_ARE_RANKED_IN_THE_FOLLOWING_ORDER);
+			LOG.debug(this.getClass().getSimpleName() + TEMPLATES_LIST_IS + this.orderedTemplateCollection.size() + TEMPLATES_ARE_RANKED_IN_THE_FOLLOWING_ORDER);
 			for (WebHookPayloadTemplate pl : this.orderedTemplateCollection){
-				Loggers.SERVER.debug(this.getClass().getSimpleName() + TEMPLATE_NAME + pl.getTemplateId() + " Rank: " + pl.getRank());
+				LOG.debug(this.getClass().getSimpleName() + TEMPLATE_NAME + pl.getTemplateId() + " Rank: " + pl.getRank());
 			}
 		}
 	}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/ExtraParameters.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/ExtraParameters.java
@@ -8,15 +8,16 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.parameters.ProcessingResult;
 import jetbrains.buildServer.parameters.ValueResolver;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.payload.PayloadTemplateEngineType;
 import webhook.teamcity.payload.variableresolver.VariableMessageBuilder;
 import webhook.teamcity.settings.project.WebHookParameter;
 import webhook.teamcity.settings.project.WebHookParameterModel;
 
 public class ExtraParameters extends ArrayList<WebHookParameterModel> {
+	private static final Logger LOG = Logger.getInstance(ExtraParameters.class.getName());
 
 	public static final String TEAMCITY = "teamcity";
 	public static final String WEBHOOK = "webhook";
@@ -79,7 +80,7 @@ public class ExtraParameters extends ArrayList<WebHookParameterModel> {
 		WebHookParameterModel previous = getActual(context, key);
 		if (previous != null) {
 			this.remove(previous);
-			Loggers.SERVER.debug("WebHookExtraParameters :: Removed existing WebHookParameter: " + previous.getContext() + " : " + previous.getName());
+			LOG.debug("WebHookExtraParameters :: Removed existing WebHookParameter: " + previous.getContext() + " : " + previous.getName());
 		}
 		WebHookParameterModel newHookParameterModel = new WebHookParameterModel(context,
 				context,
@@ -90,7 +91,7 @@ public class ExtraParameters extends ArrayList<WebHookParameterModel> {
 				FORCE_RESOLVE_TEAMCITY_VARIABLE,
 				TEMPLATE_ENGINE_TYPE);
 		add(newHookParameterModel);
-		Loggers.SERVER.debug("WebHookExtraParameters :: Added WebHookParameter: " + newHookParameterModel.getContext() + " : " + newHookParameterModel.getName());
+		LOG.debug("WebHookExtraParameters :: Added WebHookParameter: " + newHookParameterModel.getContext() + " : " + newHookParameterModel.getName());
 	}
 
 	public void putAll(String context, Map<String, String> paramMap) {
@@ -104,7 +105,7 @@ public class ExtraParameters extends ArrayList<WebHookParameterModel> {
 			WebHookParameterModel previous = getActual(context, parameter.getName());
 			if (previous != null) {
 				this.remove(previous);
-				Loggers.SERVER.debug("WebHookExtraParameters :: Removed existing WebHookParameter: " + previous.getContext() + " : " + previous.getName());
+				LOG.debug("WebHookExtraParameters :: Removed existing WebHookParameter: " + previous.getContext() + " : " + previous.getName());
 			}
 			WebHookParameterModel newHookParameterModel = new WebHookParameterModel(
 					parameter.getId(),
@@ -116,7 +117,7 @@ public class ExtraParameters extends ArrayList<WebHookParameterModel> {
 					parameter.getForceResolveTeamCityVariable(),
 					parameter.getTemplateEngine());
 			add(newHookParameterModel);
-			Loggers.SERVER.debug("WebHookExtraParameters :: Added WebHookParameter: " + newHookParameterModel.getContext() + " : " + newHookParameterModel.getName());
+			LOG.debug("WebHookExtraParameters :: Added WebHookParameter: " + newHookParameterModel.getContext() + " : " + newHookParameterModel.getName());
 		}
 		return this;
 	}
@@ -151,7 +152,7 @@ public class ExtraParameters extends ArrayList<WebHookParameterModel> {
 				if (key.equals(param.getName())) {
 					if (Boolean.TRUE.equals(param.getSecure())) {
 						this.secureValueAccessed = true;
-						Loggers.SERVER.debug(String.format("WebHookExtraParameters :: Secure value accessed for '%s' : '%s'", "no_context", key));
+						LOG.debug(String.format("WebHookExtraParameters :: Secure value accessed for '%s' : '%s'", "no_context", key));
 					}
 					return param.getValue();
 				}
@@ -178,7 +179,7 @@ public class ExtraParameters extends ArrayList<WebHookParameterModel> {
 					&& webHookParameter.getName().equals(key)) {
 				if (Boolean.TRUE.equals(webHookParameter.getSecure())) {
 					this.secureValueAccessed = true;
-					Loggers.SERVER.debug(String.format("WebHookExtraParameters :: Secure value accessed for '%s' : '%s'", context, key));
+					LOG.debug(String.format("WebHookExtraParameters :: Secure value accessed for '%s' : '%s'", context, key));
 				}
 				return webHookParameter.getValue();
 			}
@@ -227,22 +228,22 @@ public class ExtraParameters extends ArrayList<WebHookParameterModel> {
 		if (!variablesToResolve.isEmpty()) {
 			Map<String, ProcessingResult> resolvedMap = valueResolver.resolveWithDetails(variablesToResolve);
 			for ( Entry<String, ProcessingResult> e: resolvedMap.entrySet()) {
-				Loggers.SERVER.debug(String.format("WebHookExtraParameters :: Processing resolver result for '%s'", e.getKey()));
+				LOG.debug(String.format("WebHookExtraParameters :: Processing resolver result for '%s'", e.getKey()));
 				if (e.getValue().isModified()) {
-					Loggers.SERVER.debug(String.format("WebHookExtraParameters :: Value was modified for '%s'. New value is '%s'", e.getKey(), e.getValue().getResult()));
+					LOG.debug(String.format("WebHookExtraParameters :: Value was modified for '%s'. New value is '%s'", e.getKey(), e.getValue().getResult()));
 					
 					WebHookParameterModel param = getActual(PROJECT, e.getKey()); // We only support forced update on PROJECT Parameters
 					if (param != null && Boolean.TRUE.equals(param.getForceResolveTeamCityVariable())) {
-						Loggers.SERVER.debug(String.format("WebHookExtraParameters :: Found parameter with match value. Name is '%s'. New value is '%s'", param.getName(), e.getValue().getResult()));
+						LOG.debug(String.format("WebHookExtraParameters :: Found parameter with match value. Name is '%s'. New value is '%s'", param.getName(), e.getValue().getResult()));
 						param.setValue(e.getValue().getResult());
-						Loggers.SERVER.debug(String.format("WebHookExtraParameters :: Found parameter: '%s'", param.toString()));
+						LOG.debug(String.format("WebHookExtraParameters :: Found parameter: '%s'", param.toString()));
 					}
 				} else {
-					Loggers.SERVER.debug(String.format("WebHookExtraParameters :: Value was not modified for '%s'.", e.getKey()));
+					LOG.debug(String.format("WebHookExtraParameters :: Value was not modified for '%s'.", e.getKey()));
 				}
 			}
 		} else {
-			Loggers.SERVER.debug("WebHookExtraParameters :: No force resolver parameters found. Resolving will be skipped.");
+			LOG.debug("WebHookExtraParameters :: No force resolver parameters found. Resolving will be skipped.");
 		}
 		
 	}
@@ -250,7 +251,7 @@ public class ExtraParameters extends ArrayList<WebHookParameterModel> {
 		Map<String, String> variablesToResolve = new TreeMap<>();
 		for ( WebHookParameterModel param : getProjectParameters()) { // Only PROJECT parameters are foreResolvable.
 			if (Boolean.TRUE.equals(param.getForceResolveTeamCityVariable())) {
-				Loggers.SERVER.debug(String.format("WebHookExtraParameters:: Parameter '%s' is marked as forcedResolvable. %s", param.getName(), param.toString()));
+				LOG.debug(String.format("WebHookExtraParameters:: Parameter '%s' is marked as forcedResolvable. %s", param.getName(), param.toString()));
 				variablesToResolve.put(param.getName(), param.getValue());
 			}
 		}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHookPayloadContent.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/content/WebHookPayloadContent.java
@@ -10,6 +10,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.SortedMap;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.Branch;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.serverSide.SBuildRunnerDescriptor;
@@ -26,7 +27,6 @@ import jetbrains.buildServer.vcs.SVcsModification;
 import lombok.Getter;
 import lombok.Setter;
 import webhook.teamcity.BuildStateEnum;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.TeamCityIdResolver;
 import webhook.teamcity.executor.WebHookResponsibilityHolder;
 import webhook.teamcity.payload.WebHookContentObjectSerialiser;
@@ -40,6 +40,8 @@ import webhook.teamcity.payload.variableresolver.standard.WebHooksBeanUtilsVaria
 import webhook.teamcity.payload.variableresolver.VariableResolver;
 
 public class WebHookPayloadContent {
+		private static final Logger LOG = Logger.getInstance(WebHookPayloadContent.class.getName());
+
 		private static final String MAX_CHANGE_FILE_LIST_SIZE = "maxChangeFileListSize";
 		private static final String WEBHOOK_MAX_CHANGE_FILE_LIST_SIZE = "webhook." + MAX_CHANGE_FILE_LIST_SIZE;
 
@@ -438,11 +440,11 @@ public class WebHookPayloadContent {
 					setBranchDisplayName(getBranch().getDisplayName());
 					setBranchIsDefault(getBranch().isDefaultBranch());
 				} else {
-					Loggers.SERVER.debug("WebHookPayloadContent :: Branch is null. Either feature branch support is not configured or Teamcity does not support feature branches on this VCS");
+					LOG.debug("WebHookPayloadContent :: Branch is null. Either feature branch support is not configured or Teamcity does not support feature branches on this VCS");
 				}
 
 			} catch (NoSuchMethodError e){
-				Loggers.SERVER.debug("WebHookPayloadContent :: Could not get Branch Info by calling sRunningBuild.getBranch(). Probably an old version of TeamCity");
+				LOG.debug("WebHookPayloadContent :: Could not get Branch Info by calling sRunningBuild.getBranch(). Probably an old version of TeamCity");
 			}
 			setRootUrl(StringUtils.stripTrailingSlash(server.getRootUrl()) + "/");
 			setBuildStatusUrl(getRootUrl() + "viewLog.html?buildTypeId=" + getBuildTypeId() + "&buildId=" + getBuildId());
@@ -458,19 +460,19 @@ public class WebHookPayloadContent {
 				try {
 					this.maxChangeFileListSize = Integer.parseInt(extraParameters.get(MAX_CHANGE_FILE_LIST_SIZE));
 				} catch (NumberFormatException ex) {
-					Loggers.SERVER.info("WebHookPayloadContent : Unable to convert 'maxChangeFileListSize' value to a valid integer. Defaut value will be used '" + this.maxChangeFileListSize + "'");
+					LOG.info("WebHookPayloadContent : Unable to convert 'maxChangeFileListSize' value to a valid integer. Defaut value will be used '" + this.maxChangeFileListSize + "'");
 				}
 			} else if (teamcityProperties.containsKey(WEBHOOK_MAX_CHANGE_FILE_LIST_SIZE)) {
 				try {
 					this.maxChangeFileListSize = Integer.parseInt(teamcityProperties.get(WEBHOOK_MAX_CHANGE_FILE_LIST_SIZE));
 				} catch (NumberFormatException ex) {
-					Loggers.SERVER.info("WebHookPayloadContent : Unable to convert 'webhook.maxChangeFileListSize' value to a valid integer. Defaut value will be used '" + this.maxChangeFileListSize + "'");
+					LOG.info("WebHookPayloadContent : Unable to convert 'webhook.maxChangeFileListSize' value to a valid integer. Defaut value will be used '" + this.maxChangeFileListSize + "'");
 				}
 			} else if (Objects.nonNull(TeamCityProperties.getPropertyOrNull(WEBHOOK_MAX_CHANGE_FILE_LIST_SIZE))){
 				try {
 					this.maxChangeFileListSize = Integer.parseInt(TeamCityProperties.getProperty(WEBHOOK_MAX_CHANGE_FILE_LIST_SIZE));
 				} catch (NumberFormatException ex) {
-					Loggers.SERVER.info("WebHookPayloadContent : Unable to convert TeamCity global property 'webhook.maxChangeFileListSize' value to a valid integer. Defaut value will be used '" + this.maxChangeFileListSize + "'");
+					LOG.info("WebHookPayloadContent : Unable to convert TeamCity global property 'webhook.maxChangeFileListSize' value to a valid integer. Defaut value will be used '" + this.maxChangeFileListSize + "'");
 				}
 			}
 

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/format/WebHookPayloadNameValuePairs.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/format/WebHookPayloadNameValuePairs.java
@@ -5,9 +5,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URLEncoder;
 import java.util.Map;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.apache.commons.beanutils.BeanUtils;
 
-import webhook.teamcity.Loggers;
 import webhook.teamcity.payload.PayloadTemplateEngineType;
 import webhook.teamcity.payload.WebHookPayload;
 import webhook.teamcity.payload.WebHookPayloadManager;
@@ -20,6 +20,7 @@ import webhook.teamcity.payload.variableresolver.WebHookVariableResolverManager;
 
 
 public class WebHookPayloadNameValuePairs extends WebHookPayloadGeneric implements WebHookPayload {
+	private static final Logger LOG = Logger.getInstance(WebHookPayloadNameValuePairs.class.getName());
 
 	public static final String FORMAT_SHORT_NAME = "nvpairs";
 	public static final String FORMAT_CONTENT_TYPE = "application/x-www-form-urlencoded";
@@ -62,7 +63,7 @@ public class WebHookPayloadNameValuePairs extends WebHookPayloadGeneric implemen
 		try {
 			 contentMap = BeanUtils.describe(content);
 		} catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException ex) {
-			Loggers.SERVER.debug("It was not possible to convert 'content' into a bean", ex );
+			LOG.debug("It was not possible to convert 'content' into a bean", ex );
 		}
 
 		if (contentMap != null && contentMap.size() > 0){
@@ -74,7 +75,7 @@ public class WebHookPayloadNameValuePairs extends WebHookPayloadGeneric implemen
 			appendToBuilder(returnString, content.getExtraParameters(myVariableResolverFactory), "extra");
 		}
 
-		Loggers.SERVER.debug(this.getClass().getSimpleName() + ": payload is " + returnString.toString());
+		LOG.debug(this.getClass().getSimpleName() + ": payload is " + returnString.toString());
 		if (returnString.length() > 0){
 			return returnString.toString().substring(1);
 		} else {
@@ -97,7 +98,7 @@ public class WebHookPayloadNameValuePairs extends WebHookPayloadGeneric implemen
 				}
 			} catch (UnsupportedEncodingException | ClassCastException ex ) {
 				pair = "";
-				Loggers.SERVER.debug("failed to encode '" + logType + "' parameter '" + entry.getKey() + "' to URL format. Value has been converted to an empty string.", ex );
+				LOG.debug("failed to encode '" + logType + "' parameter '" + entry.getKey() + "' to URL format. Value has been converted to an empty string.", ex );
 			}
 			stringBuilder.append(pair);
 		}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/template/AbstractXmlBasedWebHookTemplate.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/template/AbstractXmlBasedWebHookTemplate.java
@@ -7,11 +7,11 @@ import java.util.Set;
 
 import javax.xml.bind.JAXBException;
 
+import com.intellij.openapi.diagnostic.Logger;
 import webhook.Constants;
 import webhook.teamcity.BuildStateEnum;
 import webhook.teamcity.DeferrableService;
 import webhook.teamcity.DeferrableServiceManager;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.ProjectIdResolver;
 import webhook.teamcity.payload.WebHookPayloadManager;
 import webhook.teamcity.payload.WebHookPayloadTemplate;
@@ -33,6 +33,7 @@ import webhook.teamcity.settings.entity.WebHookTemplateJaxHelper;
  * the <code>webhook-templates.xml</code> file. 
  */
 public abstract class AbstractXmlBasedWebHookTemplate implements WebHookPayloadTemplate, DeferrableService {
+	private static final Logger LOG = Logger.getInstance(AbstractXmlBasedWebHookTemplate.class.getName());
 
 	protected WebHookPayloadManager payloadManager;
 	protected WebHookTemplateJaxHelper webHookTemplateJaxHelper;
@@ -82,10 +83,10 @@ public abstract class AbstractXmlBasedWebHookTemplate implements WebHookPayloadT
 			this.templateManager.registerTemplateFormatFromSpring(template);
 		} else {
 			if (template.templateContent.isEmpty()){
-				Loggers.SERVER.error(getLoggingName() + " :: Failed to register template " + getTemplateId() + ". No regular template configurations were found.");
+				LOG.error(getLoggingName() + " :: Failed to register template " + getTemplateId() + ". No regular template configurations were found.");
 			}
 			if (template.branchTemplateContent.isEmpty()){
-				Loggers.SERVER.error(getLoggingName() + " :: Failed to register template " + getTemplateId() + ". No branch template configurations were found.");
+				LOG.error(getLoggingName() + " :: Failed to register template " + getTemplateId() + ". No branch template configurations were found.");
 			}
 		}
 	}
@@ -126,14 +127,14 @@ public abstract class AbstractXmlBasedWebHookTemplate implements WebHookPayloadT
 	            webhookEntity = webHookTemplateJaxHelper.readTemplate(in);
 	            webhookEntity.fixTemplateIds();
 	        } catch (IOException | JAXBException e) {
-	        	Loggers.SERVER.error(getLoggingName() + " :: An Error occurred trying to load the template properties file: " + getXmlFileName() + ".");
-	        	Loggers.SERVER.debug(e);
+	        	LOG.error(getLoggingName() + " :: An Error occurred trying to load the template properties file: " + getXmlFileName() + ".");
+	        	LOG.debug(e);
 	        	
 	        } finally {
 	           // close opened resources
 	        }
 	    } else {
-	    	Loggers.SERVER.error(getLoggingName() + " :: An Error occurred trying to load the template properties file: " + getXmlFileName() + ". The file was not found in the classpath.");
+	    	LOG.error(getLoggingName() + " :: An Error occurred trying to load the template properties file: " + getXmlFileName() + ". The file was not found in the classpath.");
 	    }
 	    return webhookEntity;
 	}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/WebHookVariableResolverManagerImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/WebHookVariableResolverManagerImpl.java
@@ -7,26 +7,27 @@ import java.util.TreeMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import jetbrains.buildServer.log.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 import webhook.teamcity.WebHookContentResolutionException;
 import webhook.teamcity.WebHookExecutionException;
 import webhook.teamcity.payload.PayloadTemplateEngineType;
 
 public class WebHookVariableResolverManagerImpl implements WebHookVariableResolverManager {
-	
+	private static final Logger LOG = Logger.getInstance(WebHookVariableResolverManagerImpl.class.getName());
+
 	Map<PayloadTemplateEngineType, VariableResolverFactory> variableResolvers = new TreeMap<>();
 	Map<String, VariableResolverFactory> variableResolversWithStringKeys = new TreeMap<>();
 	
 	@Override
 	public void registerVariableResolverFactory(VariableResolverFactory factory) {
 		if (variableResolvers.containsKey(factory.getPayloadTemplateType())) {
-			Loggers.SERVER.warn("WebHookVariableResolverManagerImpl :: Previously registered factory '" 
+			LOG.warn("WebHookVariableResolverManagerImpl :: Previously registered factory '" 
 				+ variableResolvers.get(factory.getPayloadTemplateType()).getVariableResolverFactoryName()
 				 + "' of type '"
 				+ factory.getPayloadTemplateType().toString() + "' was overridden.");
 		}
 		variableResolvers.put(factory.getPayloadTemplateType(), factory);
-		Loggers.SERVER.info("WebHookVariableResolverManagerImpl :: Registered new VariableResolverFactory '" 
+		LOG.info("WebHookVariableResolverManagerImpl :: Registered new VariableResolverFactory '" 
 				+ factory.getVariableResolverFactoryName()
 				+ "' as type '" 
 				+ factory.getPayloadTemplateType().toString() + "'");

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/standard/WebHooksBeanUtilsLegacyVariableResolverFactory.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/standard/WebHooksBeanUtilsLegacyVariableResolverFactory.java
@@ -1,14 +1,15 @@
 package webhook.teamcity.payload.variableresolver.standard;
 
-import jetbrains.buildServer.log.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 import webhook.teamcity.payload.PayloadTemplateEngineType;
 import webhook.teamcity.payload.variableresolver.VariableResolverFactory;
 
 public class WebHooksBeanUtilsLegacyVariableResolverFactory extends WebHooksBeanUtilsVariableResolverFactory implements VariableResolverFactory {
-	
+	private static final Logger LOG = Logger.getInstance(WebHooksBeanUtilsLegacyVariableResolverFactory.class.getName());
+
 	@Override
 	public void register() {
-		Loggers.SERVER.info("WebHooksBeanUtilsLegacyVariableResolverFactory :: Registering for type: " + getPayloadTemplateType().toString());
+		LOG.info("WebHooksBeanUtilsLegacyVariableResolverFactory :: Registering for type: " + getPayloadTemplateType().toString());
 		this.variableResolverManager.registerVariableResolverFactory(this);
 	}
 	

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/standard/WebHooksBeanUtilsVariableResolver.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/standard/WebHooksBeanUtilsVariableResolver.java
@@ -6,11 +6,11 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 
 import jetbrains.buildServer.serverSide.SProject;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.payload.WebHookContentObjectSerialiser;
 import webhook.teamcity.payload.content.ExtraParameters;
 import webhook.teamcity.payload.util.StringSanitiser;
@@ -29,6 +29,7 @@ import webhook.teamcity.settings.secure.WebHookSecretResolver;
  */
 
 public class WebHooksBeanUtilsVariableResolver implements VariableResolver {
+	private static final Logger LOG = Logger.getInstance(WebHooksBeanUtilsVariableResolver.class.getName());
 
 	private static final List<String> HIDDEN_FIELDS = Arrays.asList("build", "project", "buildType");
 	private static final String CAPITALISE = "capitalise(";
@@ -177,7 +178,7 @@ public class WebHooksBeanUtilsVariableResolver implements VariableResolver {
 			}
 
 		} catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-			Loggers.SERVER.debug(this.getClass().getSimpleName() + " :: " + e.getClass() + " thrown when trying to resolve value for " + variableName);
+			LOG.debug(this.getClass().getSimpleName() + " :: " + e.getClass() + " thrown when trying to resolve value for " + variableName);
 		}
 		return value;
 

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/standard/WebHooksBeanUtilsVariableResolverFactory.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/standard/WebHooksBeanUtilsVariableResolverFactory.java
@@ -1,6 +1,6 @@
 package webhook.teamcity.payload.variableresolver.standard;
 
-import jetbrains.buildServer.log.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.SProject;
 import webhook.teamcity.payload.PayloadTemplateEngineType;
 import webhook.teamcity.payload.WebHookContentObjectSerialiser;
@@ -13,13 +13,14 @@ import webhook.teamcity.settings.secure.WebHookSecretResolverFactory;
 import webhook.teamcity.payload.variableresolver.VariableResolver;
 
 public class WebHooksBeanUtilsVariableResolverFactory implements VariableResolverFactory {
-	
+	private static final Logger LOG = Logger.getInstance(WebHooksBeanUtilsVariableResolverFactory.class.getName());
+
 	WebHookVariableResolverManager variableResolverManager;
 	WebHookSecretResolver webHookSecretResolver;
 	
 	@Override
 	public void register() {
-		Loggers.SERVER.info("WebHooksBeanUtilsVariableResolverFactory :: Registering for type: " + getPayloadTemplateType().toString());
+		LOG.info("WebHooksBeanUtilsVariableResolverFactory :: Registering for type: " + getPayloadTemplateType().toString());
 		this.variableResolverManager.registerVariableResolverFactory(this);
 	}
 	

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/velocity/VelocityJsonTool.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/velocity/VelocityJsonTool.java
@@ -9,17 +9,18 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 
-import webhook.teamcity.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 
 public class VelocityJsonTool {
-	
+	private static final Logger LOG = Logger.getInstance(VelocityJsonTool.class.getName());
+
 	private Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.IDENTITY).create();
 
 	public Map<String,String> jsonToStringMap(String jsonString) {
 		try {
 			return gson.fromJson(jsonString, new TypeToken<Map<String,String>>(){}.getType());
 		} catch (JsonParseException ex) {
-			Loggers.SERVER.warn("WebHooks VelocityJsonTool :: Unable to parse string into JSON. Returning empty map from String: '" +
+			LOG.warn("WebHooks VelocityJsonTool :: Unable to parse string into JSON. Returning empty map from String: '" +
 									jsonString + "'");
 			return new HashMap<>();
 		}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/velocity/WebHooksBeanUtilsVelocityVariableResolver.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/velocity/WebHooksBeanUtilsVelocityVariableResolver.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.velocity.VelocityContext;
@@ -11,7 +12,6 @@ import org.apache.velocity.context.Context;
 import org.apache.velocity.tools.generic.DateTool;
 
 import jetbrains.buildServer.serverSide.SProject;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.payload.WebHookContentObjectSerialiser;
 import webhook.teamcity.payload.content.ExtraParameters;
 import webhook.teamcity.payload.variableresolver.VariableResolver;
@@ -28,7 +28,8 @@ import webhook.teamcity.settings.secure.WebHookSecretResolver;
  */
 
 public class WebHooksBeanUtilsVelocityVariableResolver implements VariableResolver, Context {
-	
+	private static final Logger LOG = Logger.getInstance(WebHooksBeanUtilsVelocityVariableResolver.class.getName());
+
 	
 	private static final String SECURE = "secure(";
 	private static final String SUFFIX = ")";
@@ -62,24 +63,24 @@ public class WebHooksBeanUtilsVelocityVariableResolver implements VariableResolv
 				velocityContext.put(property.getKey(), property.getValue());
 			}
 		} catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-			Loggers.SERVER.debug(this.getClass().getSimpleName() + " :: " + e.getClass() + " thrown populating context from bean"); 
-			Loggers.SERVER.debug(e);
+			LOG.debug(this.getClass().getSimpleName() + " :: " + e.getClass() + " thrown populating context from bean"); 
+			LOG.debug(e);
 		} 
 		
 		if (!velocityContext.containsKey("dateTool")) {
 			velocityContext.put("dateTool", new DateTool());
 		} else {
-			Loggers.SERVER.warn("WebHooksBeanUtilsVelocityVariableResolver :: Unable to add 'dateTool' to Velocity context. An item of that name already exists");
+			LOG.warn("WebHooksBeanUtilsVelocityVariableResolver :: Unable to add 'dateTool' to Velocity context. An item of that name already exists");
 		}
 		if (!velocityContext.containsKey("jsonTool")) {
 		    velocityContext.put("jsonTool", new VelocityJsonTool());
 		} else {
-		    Loggers.SERVER.warn("WebHooksBeanUtilsVelocityVariableResolver :: Unable to add 'jsonTool' to Velocity context. An item of that name already exists");
+		    LOG.warn("WebHooksBeanUtilsVelocityVariableResolver :: Unable to add 'jsonTool' to Velocity context. An item of that name already exists");
 		}
 		if (!velocityContext.containsKey("nullUtils")) {
 			velocityContext.put("nullUtils", new VelocityNullUtils());
 		} else {
-			Loggers.SERVER.warn("WebHooksBeanUtilsVelocityVariableResolver :: Unable to add 'nullUtils' to Velocity context. An item of that name already exists");
+			LOG.warn("WebHooksBeanUtilsVelocityVariableResolver :: Unable to add 'nullUtils' to Velocity context. An item of that name already exists");
 		}
 		
 	}
@@ -102,7 +103,7 @@ public class WebHooksBeanUtilsVelocityVariableResolver implements VariableResolv
 
 	@Override
 	public Object get(String key) {
-		Loggers.SERVER.debug(String.format("WebHooksBeanUtilsVelocityVariableResolver :: Value requested from Velocity context. 'key=%s'", key));
+		LOG.debug(String.format("WebHooksBeanUtilsVelocityVariableResolver :: Value requested from Velocity context. 'key=%s'", key));
 		if (nameMappings.containsKey(key)) {
 			// Call extraParameters.get(), so that accessing secure parameters is logged.
 			// Resolve any underscore names to dot names via the nameMappings.

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/velocity/WebHooksBeanUtilsVelocityVariableResolverFactory.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/payload/variableresolver/velocity/WebHooksBeanUtilsVelocityVariableResolverFactory.java
@@ -1,8 +1,7 @@
 package webhook.teamcity.payload.variableresolver.velocity;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.apache.velocity.context.Context;
-
-import jetbrains.buildServer.log.Loggers;
 import jetbrains.buildServer.serverSide.SProject;
 import webhook.teamcity.WebHookContentResolutionException;
 import webhook.teamcity.payload.PayloadTemplateEngineType;
@@ -16,13 +15,14 @@ import webhook.teamcity.settings.secure.WebHookSecretResolverFactory;
 import webhook.teamcity.payload.variableresolver.VariableResolver;
 
 public class WebHooksBeanUtilsVelocityVariableResolverFactory implements VariableResolverFactory {
-	
+	private static final Logger LOG = Logger.getInstance(WebHooksBeanUtilsVelocityVariableResolverFactory.class.getName());
+
 	private WebHookVariableResolverManager variableResolverManager;
 	private WebHookSecretResolver webHookSecretResolver;
 	
 	@Override
 	public void register() {
-		Loggers.SERVER.info("WebHooksBeanUtilsVariableResolverFactory :: Registering for type: " + getPayloadTemplateType().toString());
+		LOG.info("WebHooksBeanUtilsVariableResolverFactory :: Registering for type: " + getPayloadTemplateType().toString());
 		this.variableResolverManager.registerVariableResolverFactory(this);
 	}
 	

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookConfig.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookConfig.java
@@ -21,7 +21,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import jetbrains.buildServer.log.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.SBuildType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -43,6 +43,8 @@ import webhook.teamcity.settings.project.WebHookParameterModel;
 
 @Builder @AllArgsConstructor
 public class WebHookConfig {
+	private static final Logger LOG = Logger.getInstance(WebHookConfig.class.getName());
+
 	private static final String ATTR_KEY = "key";
 	private static final String ATTR_URL = "url";
 	private static final String ATTR_ID = "id";
@@ -156,7 +158,7 @@ public class WebHookConfig {
 						states.setEnabled(BuildStateEnum.findBuildState(eState.getAttributeValue(ATTR_TYPE)),
 										  eState.getAttribute(ATTR_ENABLED).getBooleanValue());
 					} catch (DataConversionException e1) {
-						Loggers.SERVER.warn(LOG_PREFIX_WEB_HOOK_CONFIG + e1.getMessage());
+						LOG.warn(LOG_PREFIX_WEB_HOOK_CONFIG + e1.getMessage());
 					}
 				}
 			}
@@ -168,14 +170,14 @@ public class WebHookConfig {
 				try {
 					this.enableForAllBuildsInProject(eTypes.getAttribute(ATTR_ENABLED_FOR_ALL).getBooleanValue());
 				} catch (DataConversionException e1) {
-					Loggers.SERVER.warn(LOG_PREFIX_WEB_HOOK_CONFIG + e1.getMessage());
+					LOG.warn(LOG_PREFIX_WEB_HOOK_CONFIG + e1.getMessage());
 				}
 			}
 			if (eTypes.getAttribute(ATTR_ENABLED_FOR_SUBPROJECTS) != null){
 				try {
 					this.enableForSubProjects(eTypes.getAttribute(ATTR_ENABLED_FOR_SUBPROJECTS).getBooleanValue());
 				} catch (DataConversionException e1) {
-					Loggers.SERVER.warn(LOG_PREFIX_WEB_HOOK_CONFIG + e1.getMessage());
+					LOG.warn(LOG_PREFIX_WEB_HOOK_CONFIG + e1.getMessage());
 				}
 			}
 			if (Boolean.FALSE.equals(isEnabledForAllBuildsInProject())){

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookMainSettings.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookMainSettings.java
@@ -2,15 +2,17 @@ package webhook.teamcity.settings;
 
 import java.util.List;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.MainConfigProcessor;
 import jetbrains.buildServer.serverSide.SBuildServer;
 
 import org.jdom.Element;
 
 import webhook.WebHookProxyConfig;
-import webhook.teamcity.Loggers;
 
 public class WebHookMainSettings implements MainConfigProcessor {
+	private static final Logger LOG = Logger.getInstance(WebHookMainSettings.class.getName());
+
 	protected static final String ATTRIBUTENAME_ENABLED = "enabled";
 	protected static final String ATTRIBUTENAME_USE_THREADED_EXECUTOR = "useThreadedExecutor";
 	protected static final String ATTRIBUTENAME_DEDICATED_THREAD_POOL = "dedicatedThreadPool";
@@ -27,7 +29,7 @@ public class WebHookMainSettings implements MainConfigProcessor {
 	}
 
 	public void register(){
-		Loggers.SERVER.debug(NAME + ":: Registering");
+		LOG.debug(NAME + ":: Registering");
 		server.registerExtension(MainConfigProcessor.class, "webhooks", this);
 	}
 
@@ -41,8 +43,8 @@ public class WebHookMainSettings implements MainConfigProcessor {
 	 * Old settings should be overwritten.
 	 */
 	{
-		Loggers.SERVER.info("WebHookMainSettings: re-reading main settings");
-		Loggers.SERVER.debug(NAME + ":readFrom :: " + rootElement.toString());
+		LOG.info("WebHookMainSettings: re-reading main settings");
+		LOG.debug(NAME + ":readFrom :: " + rootElement.toString());
 		WebHookMainConfig tempConfig = new WebHookMainConfig();
 		Element webhooksElement = rootElement.getChild("webhooks");
 		if(webhooksElement != null){
@@ -56,12 +58,12 @@ public class WebHookMainSettings implements MainConfigProcessor {
 				&& (extraInfoElement.getAttribute("url")  != null)){
 					tempConfig.setWebhookInfoText(extraInfoElement.getAttributeValue("text"));
 					tempConfig.setWebhookInfoUrl(extraInfoElement.getAttributeValue("url"));
-					Loggers.SERVER.debug(NAME + ":readFrom :: info text " + tempConfig.getWebhookInfoText());
-					Loggers.SERVER.debug(NAME + ":readFrom :: info url  " + tempConfig.getWebhookInfoUrl());
+					LOG.debug(NAME + ":readFrom :: info text " + tempConfig.getWebhookInfoText());
+					LOG.debug(NAME + ":readFrom :: info url  " + tempConfig.getWebhookInfoUrl());
 				}
 				if (extraInfoElement.getAttribute("show-reading") != null){
 					tempConfig.setWebhookShowFurtherReading(Boolean.parseBoolean(extraInfoElement.getAttributeValue("show-reading")));
-					Loggers.SERVER.debug(NAME + ":readFrom :: show reading " + tempConfig.getWebhookShowFurtherReading().toString());
+					LOG.debug(NAME + ":readFrom :: show reading " + tempConfig.getWebhookShowFurtherReading().toString());
 				}
 			}
 
@@ -133,7 +135,7 @@ public class WebHookMainSettings implements MainConfigProcessor {
 					for(Element e : namedChildren){
 						String url = e.getAttributeValue("url");
 						tempConfig.addNoProxyUrl(url);
-						Loggers.SERVER.debug(NAME + ":readFrom :: noProxyUrl " + url);
+						LOG.debug(NAME + ":readFrom :: noProxyUrl " + url);
 					}
 				}
 			}
@@ -146,8 +148,8 @@ public class WebHookMainSettings implements MainConfigProcessor {
 	 * in memory.
 	 */
 	{
-		Loggers.SERVER.info("WebHookMainSettings: re-writing main settings");
-		Loggers.SERVER.debug(NAME + ":writeTo :: " + parentElement.toString());
+		LOG.info("WebHookMainSettings: re-writing main settings");
+		LOG.debug(NAME + ":writeTo :: " + parentElement.toString());
 		Element webhooksElement = new Element("webhooks");
 		if (webHookMainConfig.useThreadedExecutorIsDefined()) {
 			webhooksElement.setAttribute(ATTRIBUTENAME_USE_THREADED_EXECUTOR, Boolean.toString(webHookMainConfig.useThreadedExecutor()));
@@ -159,8 +161,8 @@ public class WebHookMainSettings implements MainConfigProcessor {
 				&& webHookMainConfig.getProxyPort() != null && webHookMainConfig.getProxyPort() > 0 )
 		{
 			webhooksElement.addContent(webHookMainConfig.getProxyAsElement());
-			Loggers.SERVER.debug(NAME + "writeTo :: proxyHost " + webHookMainConfig.getProxyHost());
-			Loggers.SERVER.debug(NAME + "writeTo :: proxyPort " + webHookMainConfig.getProxyPort().toString());
+			LOG.debug(NAME + "writeTo :: proxyHost " + webHookMainConfig.getProxyHost());
+			LOG.debug(NAME + "writeTo :: proxyPort " + webHookMainConfig.getProxyPort().toString());
 		}
 
 		if(webHookMainConfig.getTimeoutsAsElement() != null) {
@@ -169,9 +171,9 @@ public class WebHookMainSettings implements MainConfigProcessor {
 
 		if(webHookMainConfig.getInfoUrlAsElement() != null){
 			webhooksElement.addContent(webHookMainConfig.getInfoUrlAsElement());
-			Loggers.SERVER.debug(NAME + "writeTo :: infoText " + webHookMainConfig.getWebhookInfoText());
-			Loggers.SERVER.debug(NAME + "writeTo :: InfoUrl  " + webHookMainConfig.getWebhookInfoUrl());
-			Loggers.SERVER.debug(NAME + "writeTo :: show-reading  " + webHookMainConfig.getWebhookShowFurtherReading().toString());
+			LOG.debug(NAME + "writeTo :: infoText " + webHookMainConfig.getWebhookInfoText());
+			LOG.debug(NAME + "writeTo :: InfoUrl  " + webHookMainConfig.getWebhookInfoUrl());
+			LOG.debug(NAME + "writeTo :: show-reading  " + webHookMainConfig.getWebhookShowFurtherReading().toString());
 		}
 
 		if (webHookMainConfig.getStatisticsAsElement() != null) {
@@ -198,7 +200,7 @@ public class WebHookMainSettings implements MainConfigProcessor {
 	}
 
 	public void dispose() {
-		Loggers.SERVER.debug(NAME + ":dispose() called");
+		LOG.debug(NAME + ":dispose() called");
 	}
 
 	public WebHookProxyConfig getProxyConfigForUrl(String url) {

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookProjectSettings.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookProjectSettings.java
@@ -5,17 +5,18 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.jdom.Element;
 
 import jetbrains.buildServer.serverSide.SBuildType;
 import jetbrains.buildServer.serverSide.settings.ProjectSettings;
 import webhook.teamcity.BuildState;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.auth.WebHookAuthConfig;
 import webhook.teamcity.payload.content.ExtraParameters;
 
 
 public class WebHookProjectSettings implements ProjectSettings {
+	private static final Logger LOG = Logger.getInstance(WebHookProjectSettings.class.getName());
 	private static final String NAME = WebHookProjectSettings.class.getName();
 	private Boolean webHooksEnabled = true;
 	private CopyOnWriteArrayList<WebHookConfig> webHooksConfigs;
@@ -30,7 +31,7 @@ public class WebHookProjectSettings implements ProjectSettings {
      * Old settings should be overwritten.
      */
     {
-    	Loggers.SERVER.debug("readFrom :: " + rootElement.toString());
+    	LOG.debug("readFrom :: " + rootElement.toString());
     	CopyOnWriteArrayList<WebHookConfig> configs = new CopyOnWriteArrayList<>();
     	
     	if (rootElement.getAttribute("enabled") != null){
@@ -45,11 +46,11 @@ public class WebHookProjectSettings implements ProjectSettings {
 			for(Element e :  namedChildren)
 	        {
 				WebHookConfig whConfig = new WebHookConfig(e);
-				Loggers.SERVER.debug(e.toString());
+				LOG.debug(e.toString());
 				configs.add(whConfig);
-				Loggers.SERVER.debug(NAME + ":readFrom :: url " + whConfig.getUrl());
-				Loggers.SERVER.debug(NAME + ":readFrom :: enabled " + whConfig.getEnabled());
-				Loggers.SERVER.debug(NAME + ":readFrom :: payloadTemplate " + whConfig.getPayloadTemplate());
+				LOG.debug(NAME + ":readFrom :: url " + whConfig.getUrl());
+				LOG.debug(NAME + ":readFrom :: enabled " + whConfig.getEnabled());
+				LOG.debug(NAME + ":readFrom :: payloadTemplate " + whConfig.getPayloadTemplate());
 	        }
 			this.webHooksConfigs = configs;
     	}
@@ -60,17 +61,17 @@ public class WebHookProjectSettings implements ProjectSettings {
      * in memory. 
      */
     {
-    	Loggers.SERVER.debug(NAME + ":writeTo :: " + parentElement.toString());
+    	LOG.debug(NAME + ":writeTo :: " + parentElement.toString());
     	parentElement.setAttribute("enabled", String.valueOf(this.webHooksEnabled));
         if(webHooksConfigs != null)
         {
             for(WebHookConfig whc : webHooksConfigs){
             	Element el = whc.getAsElement();
-            	Loggers.SERVER.debug(el.toString());
+            	LOG.debug(el.toString());
                 parentElement.addContent(el);
-				Loggers.SERVER.debug(NAME + ":writeTo :: url " + whc.getUrl());
-				Loggers.SERVER.debug(NAME + ":writeTo :: enabled " + whc.getEnabled());
-				Loggers.SERVER.debug(NAME + ":writeTo :: payloadTemplate " + whc.getPayloadTemplate());
+				LOG.debug(NAME + ":writeTo :: url " + whc.getUrl());
+				LOG.debug(NAME + ":writeTo :: enabled " + whc.getEnabled());
+				LOG.debug(NAME + ":writeTo :: payloadTemplate " + whc.getPayloadTemplate());
             }
 
         }
@@ -123,7 +124,7 @@ public class WebHookProjectSettings implements ProjectSettings {
             for(WebHookConfig whc : webHooksConfigs)
             {
                 if (whc.getUniqueKey().equals(webHookId)){
-                	Loggers.SERVER.debug(NAME + ":deleteWebHook :: Deleting webhook from " + projectId + " with URL " + whc.getUrl());
+                	LOG.debug(NAME + ":deleteWebHook :: Deleting webhook from " + projectId + " with URL " + whc.getUrl());
                 	tempWebHookList.add(whc);
                 	configToDelete = whc;
                 }
@@ -200,7 +201,7 @@ public class WebHookProjectSettings implements ProjectSettings {
             		if (headers != null) {
             			whc.setHeaders(headers);
             		}
-                	Loggers.SERVER.debug(NAME + ":updateWebHook :: Updating webhook from " + projectId + " with URL " + whc.getUrl());
+                	LOG.debug(NAME + ":updateWebHook :: Updating webhook from " + projectId + " with URL " + whc.getUrl());
                    	updateSuccess = true;
                    	configToUpdate = whc;
                 }
@@ -217,18 +218,18 @@ public class WebHookProjectSettings implements ProjectSettings {
 	public WebHookUpdateResult addNewWebHook(String projectInternalId, String projectExternalId, String url, Boolean enabled, BuildState buildState, String template, boolean buildTypeAll, boolean buildTypeSubProjects, Set<String> buildTypesEnabled, WebHookAuthConfig webHookAuthConfig, ExtraParameters extraParameters, List<WebHookFilterConfig> filters, List<WebHookHeaderConfig> headers, boolean hideSecureValues) {
 		WebHookConfig newWebHook = new WebHookConfig(projectInternalId, projectExternalId, url, enabled, buildState, template, buildTypeAll, buildTypeSubProjects, buildTypesEnabled, webHookAuthConfig, extraParameters, filters, headers, hideSecureValues); 
 		this.webHooksConfigs.add(newWebHook);
-		Loggers.SERVER.debug(NAME + ":addNewWebHook :: Adding webhook to " + projectExternalId + " with URL " + url);
+		LOG.debug(NAME + ":addNewWebHook :: Adding webhook to " + projectExternalId + " with URL " + url);
 		return new WebHookUpdateResult(true, newWebHook);
 	}
 	
 	public WebHookUpdateResult addNewWebHook(WebHookConfig webHookConfig) {
 		this.webHooksConfigs.add(webHookConfig);
-		Loggers.SERVER.debug(NAME + ":addNewWebHook :: Adding webhook to " + webHookConfig.getProjectExternalId() + " with URL " + webHookConfig.getUrl());
+		LOG.debug(NAME + ":addNewWebHook :: Adding webhook to " + webHookConfig.getProjectExternalId() + " with URL " + webHookConfig.getUrl());
 		return new WebHookUpdateResult(true, webHookConfig);
 	}
     
 	public void dispose() {
-		Loggers.SERVER.debug(NAME + ":dispose() called");
+		LOG.debug(NAME + ":dispose() called");
 	}
 
 	public Integer getWebHooksCount(){

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookProjectSettingsFactory.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookProjectSettingsFactory.java
@@ -1,18 +1,19 @@
 package webhook.teamcity.settings;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.settings.ProjectSettingsFactory;
 import jetbrains.buildServer.serverSide.settings.ProjectSettingsManager;
-import webhook.teamcity.Loggers;
 
 public class WebHookProjectSettingsFactory implements ProjectSettingsFactory {
-	
+	private static final Logger LOG = Logger.getInstance(WebHookProjectSettingsFactory.class.getName());
+
     public WebHookProjectSettingsFactory(ProjectSettingsManager projectSettingsManager){
-		Loggers.SERVER.debug("WebHookProjectSettingsFactory :: Registering");
+		LOG.debug("WebHookProjectSettingsFactory :: Registering");
 		projectSettingsManager.registerSettingsFactory("webhooks", this);
 	}
 
 	public WebHookProjectSettings createProjectSettings(String projectId) {
-		Loggers.SERVER.info("WebHookProjectSettingsFactory: re-reading settings for " + projectId);
+		LOG.info("WebHookProjectSettingsFactory: re-reading settings for " + projectId);
 		return new WebHookProjectSettings();
 	}
 

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookSettingsManagerImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/WebHookSettingsManagerImpl.java
@@ -210,8 +210,8 @@ public class WebHookSettingsManagerImpl implements WebHookSettingsManager, WebHo
 	private boolean persist(String projectInternalId, String message) {
 		try {
 			SProject project = this.myProjectManager.findProjectById(projectInternalId);
-//			ConfigAction cause = myConfigActionFactory.createAction(project, message);
-			//project.persist(cause);
+			ConfigAction cause = myConfigActionFactory.createAction(project, message);
+			project.persist(cause);
 			return true;
 		} catch (AccessDeniedException | PersistFailedException ex) {
 			LOG.warn("WebHookSettingsManagerImpl :: Failed to persist webhook in projectId: " + projectInternalId, ex);

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/project/WebHookParameterStoreFactoryImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/project/WebHookParameterStoreFactoryImpl.java
@@ -1,11 +1,12 @@
 package webhook.teamcity.settings.project;
 
-import jetbrains.buildServer.log.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.SBuildServer;
 import webhook.teamcity.TeamCityCoreFacade;
 
 public class WebHookParameterStoreFactoryImpl implements WebHookParameterStoreFactory {
-	
+
+	private static final Logger LOG = Logger.getInstance(WebHookParameterStoreFactoryImpl.class.getName());
 	private static final int MINIMUM_SUPPORTED_VERSION = 42002;  // TeamCity 10
 	private WebHookParameterStore webHookParameterStore;
 
@@ -19,9 +20,9 @@ public class WebHookParameterStoreFactoryImpl implements WebHookParameterStoreFa
 			}
 		} catch (NumberFormatException ex) {
 			webHookParameterStore = new WebHookParameterStoreNoOpImpl();
-			Loggers.SERVER.debug("WebHookParameterStoreFactory:: NumberFormatException... WebHookParameterStore is: '" + webHookParameterStore.getClass() + "'.");
+			LOG.debug("WebHookParameterStoreFactory:: NumberFormatException... WebHookParameterStore is: '" + webHookParameterStore.getClass() + "'.");
 		}
-		Loggers.SERVER.debug("WebHookParameterStoreFactory:: Teamcity build is: '" + sBuildServer.getBuildNumber() + "'. WebHookParameterStore is: '" + webHookParameterStore.getClass() + "'.");
+		LOG.debug("WebHookParameterStoreFactory:: Teamcity build is: '" + sBuildServer.getBuildNumber() + "'. WebHookParameterStore is: '" + webHookParameterStore.getClass() + "'.");
 	}
 	
 	@Override

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/project/WebHookParameterStoreImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/project/WebHookParameterStoreImpl.java
@@ -9,14 +9,15 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import jetbrains.buildServer.serverSide.SProject;
 import jetbrains.buildServer.serverSide.SProjectFeatureDescriptor;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.TeamCityCoreFacade;
 
 public class WebHookParameterStoreImpl implements WebHookParameterStore {
+	private static final Logger LOG = Logger.getInstance(WebHookParameterStoreImpl.class.getName());
 
     private static final String PROJECT_FEATURE_TYPE = "tcWebHookParameter";
 
@@ -32,7 +33,7 @@ public class WebHookParameterStoreImpl implements WebHookParameterStore {
         SProject sProject = teamCityCore.findProjectByIntId(projectInternalId);
         SProjectFeatureDescriptor featureDescriptor = sProject.addFeature(PROJECT_FEATURE_TYPE, params);
         teamCityCore.persist(projectInternalId, "WebHookParameter added");
-        Loggers.SERVER.info("WebHookParameter '" + webhookParameter.getName() + "' is created in the project " + projectInternalId);
+        LOG.info("WebHookParameter '" + webhookParameter.getName() + "' is created in the project " + projectInternalId);
         return fromProjectFeature(featureDescriptor);
     }
 
@@ -72,7 +73,7 @@ public class WebHookParameterStoreImpl implements WebHookParameterStore {
     	}
 		SProjectFeatureDescriptor feature = project.findFeatureById(webhookParameter.getId());
 		if (feature == null) {
-			Loggers.SERVER.warn("WebHookParameterStoreImpl :: Unable to find existing WebHookParameter instance "
+			LOG.warn("WebHookParameterStoreImpl :: Unable to find existing WebHookParameter instance "
 					+ " to update with ID: " + webhookParameter.getName());
 			return false;
 		}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/secure/WebHookSecretResolverFactory.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/secure/WebHookSecretResolverFactory.java
@@ -1,10 +1,11 @@
 package webhook.teamcity.settings.secure;
 
-import jetbrains.buildServer.log.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.SBuildServer;
 
 public class WebHookSecretResolverFactory {
-	
+	private static final Logger LOG = Logger.getInstance(WebHookSecretResolverFactory.class.getName());
+
 	private static final int MINIMUM_SUPPORTED_VERSION = 46533;
 	private WebHookSecretResolver webHookSecretResolver;
 	
@@ -17,9 +18,9 @@ public class WebHookSecretResolverFactory {
 			}
 		} catch (NumberFormatException ex) {
 			webHookSecretResolver = new WebHookSecretResolverNoOpImpl();
-			Loggers.SERVER.debug("WebHookSecretResolverFactory:: NumberFormatException... WebHookSecretResolver is: '" + webHookSecretResolver.getClass() + "'.");
+			LOG.debug("WebHookSecretResolverFactory:: NumberFormatException... WebHookSecretResolver is: '" + webHookSecretResolver.getClass() + "'.");
 		}
-		Loggers.SERVER.debug("WebHookSecretResolverFactory:: Teamcity build is: '" + sBuildServer.getBuildNumber() + "'. WebHookSecretResolver is: '" + webHookSecretResolver.getClass() + "'.");
+		LOG.debug("WebHookSecretResolverFactory:: Teamcity build is: '" + sBuildServer.getBuildNumber() + "'. WebHookSecretResolver is: '" + webHookSecretResolver.getClass() + "'.");
 	}
 	
 	public WebHookSecretResolver getWebHookSecretResolver() {

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/secure/WebHookSecretResolverImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/secure/WebHookSecretResolverImpl.java
@@ -24,7 +24,7 @@ public class WebHookSecretResolverImpl implements WebHookSecretResolver {
 		}
 		// Will try to resolve the token's associated value, or will return the same token unresolved. 
 		final String value = ((SecureDataStorage) sProject).getSecureValue(token, "WebHook payload assembly");
-
+		
 		// If we got the same token back, a match was not found. So return null.
 		if (!token.equals(value)) {
 			return value;

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/secure/WebHookSecretResolverImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/secure/WebHookSecretResolverImpl.java
@@ -25,7 +25,7 @@ public class WebHookSecretResolverImpl implements WebHookSecretResolver {
 		// Will try to resolve the token's associated value, or will return the same token unresolved. 
 		final String value = ((SecureDataStorage) sProject).getSecureValue(token, "WebHook payload assembly");
 		
-		// If we got the same token back, a match was not found. So return null.
+		// If we got the same token back, a match was not found. So return null. 
 		if (!token.equals(value)) {
 			return value;
 		}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/secure/WebHookSecretResolverImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/secure/WebHookSecretResolverImpl.java
@@ -1,8 +1,8 @@
 package webhook.teamcity.settings.secure;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.apache.commons.lang3.StringUtils;
 
-import jetbrains.buildServer.log.Loggers;
 import jetbrains.buildServer.serverSide.SProject;
 import jetbrains.buildServer.serverSide.impl.SecureDataStorage;
 
@@ -11,9 +11,10 @@ import jetbrains.buildServer.serverSide.impl.SecureDataStorage;
  *
  */
 public class WebHookSecretResolverImpl implements WebHookSecretResolver {
-	
+	private static final Logger LOG = Logger.getInstance(WebHookSecretResolverImpl.class.getName());
+
 	public WebHookSecretResolverImpl() {
-		Loggers.SERVER.info("WebHookSecretResolverImpl :: Starting WebHookSecretResolver for 2017.1 and newer");
+		LOG.info("WebHookSecretResolverImpl :: Starting WebHookSecretResolver for 2017.1 and newer");
 	}
 
 	@Override
@@ -23,8 +24,8 @@ public class WebHookSecretResolverImpl implements WebHookSecretResolver {
 		}
 		// Will try to resolve the token's associated value, or will return the same token unresolved. 
 		final String value = ((SecureDataStorage) sProject).getSecureValue(token, "WebHook payload assembly");
-		
-		// If we got the same token back, a match was not found. So return null. 
+
+		// If we got the same token back, a match was not found. So return null.
 		if (!token.equals(value)) {
 			return value;
 		}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/settings/secure/WebHookSecretResolverNoOpImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/settings/secure/WebHookSecretResolverNoOpImpl.java
@@ -1,12 +1,13 @@
 package webhook.teamcity.settings.secure;
 
-import jetbrains.buildServer.log.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.SProject;
 
 public class WebHookSecretResolverNoOpImpl implements WebHookSecretResolver {
-	
+	private static final Logger LOG = Logger.getInstance(WebHookSecretResolverNoOpImpl.class.getName());
+
 	public WebHookSecretResolverNoOpImpl() {
-		Loggers.SERVER.info("WebHookSecretResolverNoOpImpl :: Starting WebHookSecretResolver for verions older than 2017.1");
+		LOG.info("WebHookSecretResolverNoOpImpl :: Starting WebHookSecretResolver for verions older than 2017.1");
 	}
 
 

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/statistics/JaxHelperImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/statistics/JaxHelperImpl.java
@@ -9,9 +9,10 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
 
-import webhook.teamcity.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 
 public class JaxHelperImpl<T> implements JaxHelper<T> {
+	private static final Logger LOG = Logger.getInstance(JaxHelperImpl.class.getName());
 
 	@SuppressWarnings("unchecked")
 	@Override
@@ -39,7 +40,7 @@ public class JaxHelperImpl<T> implements JaxHelper<T> {
 		Marshaller m = context.createMarshaller();
 		m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
 		m.marshal(bean, new File(configFilePath));
-		Loggers.SERVER.debug(String.format("JaxHelperImpl :: File written to [%s]", configFilePath));
+		LOG.debug(String.format("JaxHelperImpl :: File written to [%s]", configFilePath));
 	}
 
 }

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/statistics/StatisticsSnapshot.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/statistics/StatisticsSnapshot.java
@@ -11,18 +11,19 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.joda.time.LocalDate;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import webhook.teamcity.BuildStateEnum;
-import webhook.teamcity.Loggers;
 
 @Data @NoArgsConstructor
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
 public class StatisticsSnapshot {
+
 	@XmlAttribute
 	private LocalDate date;
 	
@@ -36,6 +37,8 @@ public class StatisticsSnapshot {
 	@Data @AllArgsConstructor @NoArgsConstructor
 	@XmlAccessorType(XmlAccessType.FIELD)
 	public static class StatisticsItem {
+		private static final Logger LOG = Logger.getInstance(StatisticsItem.class.getName());
+
 		String name;
 		int invocations;
 		
@@ -47,7 +50,7 @@ public class StatisticsSnapshot {
 				if (buildStateEnum != null && buildStateEnum.equals(statisticsItemStatus.state) && status == statisticsItemStatus.statusCode) {
 					return statisticsItemStatus.count;
 				} else if (buildStateEnum == null || statisticsItemStatus.state == null || statisticsItemStatus.statusCode == null) {
-					Loggers.SERVER.debug(
+					LOG.debug(
 							String.format("StatisticsItem :: Unexpected null item. [buildStateEnum=%s,statisticsItemStatus.state=%s,statisticsItemStatus.statusCode=%s",
 									buildStateEnum, statisticsItemStatus.state, statisticsItemStatus.statusCode));
 				}
@@ -61,7 +64,7 @@ public class StatisticsSnapshot {
 					statisticsItemStatus.count = statusCount;
 					found = true;
 				} else if (buildStateEnum == null || statisticsItemStatus.state == null || statisticsItemStatus.statusCode == null) {
-					Loggers.SERVER.debug(
+					LOG.debug(
 							String.format("StatisticsItem :: Unexpected null item. [buildStateEnum=%s,statisticsItemStatus.state=%s,statisticsItemStatus.statusCode=%s",
 									buildStateEnum, statisticsItemStatus.state, statisticsItemStatus.statusCode));
 				}

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/testing/WebHookConfigFactoryImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/testing/WebHookConfigFactoryImpl.java
@@ -5,11 +5,11 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.SBuildServer;
 import jetbrains.buildServer.serverSide.SProject;
 import webhook.teamcity.BuildState;
 import webhook.teamcity.BuildStateEnum;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.payload.WebHookTemplateManager;
 import webhook.teamcity.payload.content.ExtraParameters;
 import webhook.teamcity.settings.CustomMessageTemplate;
@@ -22,6 +22,7 @@ import webhook.teamcity.testing.model.WebHookExecutionRequest;
 import webhook.teamcity.testing.model.WebHookTemplateExecutionRequest;
 
 public class WebHookConfigFactoryImpl implements WebHookConfigFactory {
+	private static final Logger LOG = Logger.getInstance(WebHookConfigFactoryImpl.class.getName());
 
 	private final SBuildServer myServer;
 	private final WebHookSettingsManager myWebHookSettingsManager;
@@ -110,8 +111,8 @@ public class WebHookConfigFactoryImpl implements WebHookConfigFactory {
 			    	for (WebHookConfig whc : projSettings.getWebHooksConfigs()){
 			    		if (whc.isEnabledForSubProjects() == false && !myProject.getProjectId().equals(project.getProjectId())){
 			    			// Sub-projects are disabled and we are a subproject.
-			    			if (Loggers.SERVER.isDebugEnabled()){
-				    			Loggers.SERVER.debug(this.getClass().getSimpleName() + ":getListOfEnabledWebHooks() "
+			    			if (LOG.isDebugEnabled()){
+				    			LOG.debug(this.getClass().getSimpleName() + ":getListOfEnabledWebHooks() "
 				    					+ ":: subprojects not enabled. myProject is: " + myProject.getProjectId() + ". webhook project is: " + project.getProjectId());
 			    			}
 			    			continue;
@@ -129,7 +130,7 @@ public class WebHookConfigFactoryImpl implements WebHookConfigFactory {
 						}
 			    	}
 		    	} else {
-		    		Loggers.SERVER.debug("WebHookUserRequestedExecutorImpl :: WebHooks are disasbled for  " + projectExternalId);
+		    		LOG.debug("WebHookUserRequestedExecutorImpl :: WebHooks are disasbled for  " + projectExternalId);
 		    	}
 		}
     	throw new WebHookConfigNotFoundException(String.format("Webhook Configuration %s was not found", webHookConfigUniqueId));

--- a/tcwebhooks-core/src/main/java/webhook/teamcity/testing/WebHookUserRequestedExecutorImpl.java
+++ b/tcwebhooks-core/src/main/java/webhook/teamcity/testing/WebHookUserRequestedExecutorImpl.java
@@ -4,6 +4,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.joda.time.LocalDateTime;
 
 import jetbrains.buildServer.responsibility.ResponsibilityEntry.State;
@@ -13,7 +14,6 @@ import jetbrains.buildServer.serverSide.SBuildType;
 import webhook.WebHook;
 import webhook.WebHookExecutionStats;
 import webhook.teamcity.BuildStateEnum;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.ProjectIdResolver;
 import webhook.teamcity.WebHookContentBuilder;
 import webhook.teamcity.WebHookExecutionException;
@@ -47,6 +47,7 @@ import webhook.teamcity.testing.model.WebHookRenderResult;
 import webhook.teamcity.testing.model.WebHookTemplateExecutionRequest;
 
 public class WebHookUserRequestedExecutorImpl implements WebHookUserRequestedExecutor {
+	private static final Logger LOG = Logger.getInstance(WebHookUserRequestedExecutorImpl.class.getName());
 
 	private static final String A_TESTING_USER = "a testing user";
 	private static final String A_TEST_EXECUTION_COMMENT = "A test execution comment";
@@ -167,7 +168,7 @@ public class WebHookUserRequestedExecutorImpl implements WebHookUserRequestedExe
 		try {
 			return new WebHookRenderResult(renderer.render(wh.getPayload()), webHookPayload.getFormatShortName());
 		} catch (WebHookHtmlRendererException ex){
-			Loggers.SERVER.info(ex);
+			LOG.info(ex);
 			return new WebHookRenderResult(wh.getPayload(), ex);
 		}
 	}
@@ -245,7 +246,7 @@ public class WebHookUserRequestedExecutorImpl implements WebHookUserRequestedExe
 		try {
 			return new WebHookRenderResult(renderer.render(wh.getPayload()), webHookTemplateExecutionRequest.getFormat());
 		} catch (WebHookHtmlRendererException ex){
-			Loggers.SERVER.info(ex);
+			LOG.info(ex);
 			return new WebHookRenderResult(wh.getPayload(), ex);
 		}
 

--- a/tcwebhooks-core/src/test/java/webhook/teamcity/testing/WebHookUserRequestedExecutorImplTest.java
+++ b/tcwebhooks-core/src/test/java/webhook/teamcity/testing/WebHookUserRequestedExecutorImplTest.java
@@ -20,6 +20,7 @@ import java.util.TreeMap;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.bind.JAXBException;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.jdom.JDOMException;
 import org.joda.time.LocalDateTime;
 import org.junit.Before;
@@ -27,7 +28,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import jetbrains.buildServer.log.Loggers;
 import jetbrains.buildServer.messages.Status;
 import jetbrains.buildServer.parameters.ParametersProvider;
 import jetbrains.buildServer.serverSide.ProjectManager;
@@ -88,8 +88,8 @@ import webhook.testframework.WebHookMockingFramework;
 import webhook.testframework.WebHookMockingFrameworkImpl;
 
 public class WebHookUserRequestedExecutorImplTest extends WebHookTestServerTestBase {
-	
-	
+	private static final Logger LOG = Logger.getInstance(WebHookUserRequestedExecutorImplTest.class.getName());
+
 	private SBuildServer server = mock(SBuildServer.class);
 	private WebHookParameterStore webHookParameterStore = mock(WebHookParameterStore.class);
 	private WebHookParameterStoreFactory webHookParameterStoreFactory = mock(WebHookParameterStoreFactory.class);
@@ -205,10 +205,10 @@ public class WebHookUserRequestedExecutorImplTest extends WebHookTestServerTestB
 		
 		WebHookRenderResult payload = executorImpl.requestWebHookPreview(webHookExecutionRequest);
 		
-		Loggers.SERVER.debug("################# " + payload);
+		LOG.debug("################# " + payload);
 		assertEquals(true, payload.getHtml().contains("http://teamcity/viewLog.html?buildTypeId=name"));
 		
-		Loggers.SERVER.debug(WebHookExecutionRequestGsonBuilder.gsonBuilder().toJson(webHookExecutionRequest));
+		LOG.debug(WebHookExecutionRequestGsonBuilder.gsonBuilder().toJson(webHookExecutionRequest));
 		
 	}
 	
@@ -245,7 +245,7 @@ public class WebHookUserRequestedExecutorImplTest extends WebHookTestServerTestB
 				.build();
 		WebHookRenderResult payload = executorImpl.requestWebHookPreview(webHookTemplateExecutionRequest);
 		
-		Loggers.SERVER.debug("################# " + payload);
+		LOG.debug("################# " + payload);
 		assertEquals(true, payload.getHtml().contains("branch_buildId"));
 
 	}	
@@ -495,7 +495,7 @@ public class WebHookUserRequestedExecutorImplTest extends WebHookTestServerTestB
 		
 		assertEquals("HttpClient should be invoked exactly once", 1, httpClient.getInvocationCount());
 		assertEquals("Expect 801 since there is no server running on port 12345", 801, historyItem.getWebhookErrorStatus().getErrorCode());
-		Loggers.SERVER.debug("################# " + historyItem.getWebhookErrorStatus().getMessage());
+		LOG.debug("################# " + historyItem.getWebhookErrorStatus().getMessage());
 		assertEquals(true, historyItem.getWebhookErrorStatus().getMessage().contains("Connection refused"));
 
 	}

--- a/tcwebhooks-rest-api-legacy/src/main/java/webhook/teamcity/server/WebHookTeamCityRestApiZipPluginFixer.java
+++ b/tcwebhooks-rest-api-legacy/src/main/java/webhook/teamcity/server/WebHookTeamCityRestApiZipPluginFixer.java
@@ -21,14 +21,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.SBuildServer;
 import lombok.Getter;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.server.pluginfixer.JarReport;
 
 public class WebHookTeamCityRestApiZipPluginFixer {
-	
+	private static final Logger LOG = Logger.getInstance(WebHookTeamCityRestApiZipPluginFixer.class.getName());
+
 	private SBuildServer mySBuildServer;
 
 	public WebHookTeamCityRestApiZipPluginFixer(SBuildServer sBuildServer) {
@@ -71,12 +71,12 @@ public class WebHookTeamCityRestApiZipPluginFixer {
 	}
 	
 	public synchronized void findRestApiZipPlugins() {
-		Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: Starting to check if rest-api.zip has jaxb jars");
+		LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: Starting to check if rest-api.zip has jaxb jars");
 		File possibleLocation = findTeamCityBaseLocation();
 		this.foundApiZipFiles = new ArrayList<>();
 		
 		if (possibleLocation != null) {
-			Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: Looking for teamcity in: " + possibleLocation.getAbsolutePath());
+			LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: Looking for teamcity in: " + possibleLocation.getAbsolutePath());
 			try {
 				foundApiZipFiles.addAll(findRestApiZipFileInTomcatDir(possibleLocation, "rest-api.zip")); 
 				
@@ -86,57 +86,57 @@ public class WebHookTeamCityRestApiZipPluginFixer {
 						jarReports.put(p, new JarReport(p, restApiUnpackedDir, filenames));
 					}
 					if (doesRestApiZipFileContainJaxJars(p.toFile(), filenames, jarReports.get(p))) {
-						Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: File found does contain jars: " + p.toFile().getAbsolutePath());
+						LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: File found does contain jars: " + p.toFile().getAbsolutePath());
 					} else {
-						Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: Hooray! File found does not contain jars. Searched in: " + p.toFile().getAbsolutePath());
+						LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: Hooray! File found does not contain jars. Searched in: " + p.toFile().getAbsolutePath());
 					}
-					Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: Looking for unpacked jars in: " + restApiUnpackedDir);
+					LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: Looking for unpacked jars in: " + restApiUnpackedDir);
 					if (doFilesExistInPluginsUnpackedDir(p.toFile().getParent(), filenames, jarReports.get(p))) {
-						Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: Unpacked dir does contain jars: " + restApiUnpackedDir);
+						LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: Unpacked dir does contain jars: " + restApiUnpackedDir);
 					} else {
-						Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: Hooray! Unpacked dir does not contain jars. Searched in: " + restApiUnpackedDir);
+						LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: Hooray! Unpacked dir does not contain jars. Searched in: " + restApiUnpackedDir);
 					}
 				}
 			} catch (IOException e) {
-				Loggers.SERVER.warnAndDebugDetails("WebHookTeamCityRestApiZipPluginFixer :: Could not open zip file rest-api.zip", e);
+				LOG.warnAndDebugDetails("WebHookTeamCityRestApiZipPluginFixer :: Could not open zip file rest-api.zip", e);
 			}
 		} else {
-			Loggers.SERVER.warn("WebHookTeamCityRestApiZipPluginFixer :: Unable to determine teamcity install location. No attempt will be made to fix rest-api.zip");
+			LOG.warn("WebHookTeamCityRestApiZipPluginFixer :: Unable to determine teamcity install location. No attempt will be made to fix rest-api.zip");
 		}
 	}
 	
 	public synchronized JarReport fixRestApiZipPlugin(Path p) {
 		try {
 				if (doesRestApiZipFileContainJaxJars(p.toFile(), filenames, jarReports.get(p))) {
-					Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: File found does contain jars. Attempting to remove them from: " + p.toFile().getAbsolutePath());
+					LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: File found does contain jars. Attempting to remove them from: " + p.toFile().getAbsolutePath());
 					deleteFilesFromRestApiZipFile(p.toFile(), filenames, jarReports.get(p));
 					if (doesRestApiZipFileContainJaxJars(p.toFile(), filenames, jarReports.get(p))) {
-						Loggers.SERVER.warn("WebHookTeamCityRestApiZipPluginFixer :: File found does contain jars. It was not possible to remove them from: " + p.toFile().getAbsolutePath());
+						LOG.warn("WebHookTeamCityRestApiZipPluginFixer :: File found does contain jars. It was not possible to remove them from: " + p.toFile().getAbsolutePath());
 					} else {
-						Loggers.SERVER.info("WebHookTeamCityRestApiZipPluginFixer :: Successfully removed jaxb jars from: " + p.toFile().getAbsolutePath());
-						Loggers.SERVER.info("WebHookTeamCityRestApiZipPluginFixer :: Please restart TeamCity so that the updated plugin file is loaded.");
+						LOG.info("WebHookTeamCityRestApiZipPluginFixer :: Successfully removed jaxb jars from: " + p.toFile().getAbsolutePath());
+						LOG.info("WebHookTeamCityRestApiZipPluginFixer :: Please restart TeamCity so that the updated plugin file is loaded.");
 						this.haveFilesBeenCleanedSinceBoot = true;
 					}
 				} else {
-					Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: Hooray! File found does not contain jars. Searched in: " + p.toFile().getAbsolutePath());
+					LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: Hooray! File found does not contain jars. Searched in: " + p.toFile().getAbsolutePath());
 				}
 				String restApiUnpackedDir = p.toFile().getParent() + UNPACKED_LOCATION;
-				Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: Looking for unpacked jars in: " + restApiUnpackedDir);
+				LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: Looking for unpacked jars in: " + restApiUnpackedDir);
 				if (doFilesExistInPluginsUnpackedDir(p.toFile().getParent(), filenames, jarReports.get(p))) {
-					Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: Unpacked dir does contain jars. Attempting to remove them from: " + restApiUnpackedDir);
+					LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: Unpacked dir does contain jars. Attempting to remove them from: " + restApiUnpackedDir);
 					deleteFilesFromPluginsUnpackedDir(filenames, jarReports.get(p));
 					if (doFilesExistInPluginsUnpackedDir(p.toFile().getParent(), filenames, jarReports.get(p))) {
-						Loggers.SERVER.warn("WebHookTeamCityRestApiZipPluginFixer :: Unpacked dir still contains jars. It was not possible to remove them from: " + restApiUnpackedDir);
+						LOG.warn("WebHookTeamCityRestApiZipPluginFixer :: Unpacked dir still contains jars. It was not possible to remove them from: " + restApiUnpackedDir);
 					} else {
-						Loggers.SERVER.info("WebHookTeamCityRestApiZipPluginFixer :: Successfully removed jaxb jars from unpacked dir : " + restApiUnpackedDir);
-						Loggers.SERVER.info("WebHookTeamCityRestApiZipPluginFixer :: Please restart TeamCity so that the updated plugin file is loaded.");
+						LOG.info("WebHookTeamCityRestApiZipPluginFixer :: Successfully removed jaxb jars from unpacked dir : " + restApiUnpackedDir);
+						LOG.info("WebHookTeamCityRestApiZipPluginFixer :: Please restart TeamCity so that the updated plugin file is loaded.");
 						this.haveFilesBeenCleanedSinceBoot = true;
 					}
 				} else {
-					Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: Hooray! Unpacked dir does not contain jars. Searched in: " + restApiUnpackedDir);
+					LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: Hooray! Unpacked dir does not contain jars. Searched in: " + restApiUnpackedDir);
 				}
 		} catch (IOException e) {
-			Loggers.SERVER.warnAndDebugDetails("WebHookTeamCityRestApiZipPluginFixer :: Could not remove files from rest-api.zip", e);
+			LOG.warnAndDebugDetails("WebHookTeamCityRestApiZipPluginFixer :: Could not remove files from rest-api.zip", e);
 		}
 		return jarReports.get(p);
 	}
@@ -145,28 +145,28 @@ public class WebHookTeamCityRestApiZipPluginFixer {
 		
 		File teamCityHome = new File(this.mySBuildServer.getServerRootPath() + "/WEB-INF");
 		if (teamCityHome.exists() && teamCityHome.isDirectory()) {
-			Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: TeamCity WEB-INF is: " + teamCityHome.getAbsolutePath());
+			LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: TeamCity WEB-INF is: " + teamCityHome.getAbsolutePath());
 			return teamCityHome;
 		}
 		
 		Map<String, String> env = System.getenv();
 		File catalinaHome = getCatalinaHomeDir(env); 
 		if (catalinaHome != null) {
-			Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: CATALINA_HOME is: " + catalinaHome.getAbsolutePath());
+			LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: CATALINA_HOME is: " + catalinaHome.getAbsolutePath());
 			return catalinaHome;
 		} else {
 			for (Entry<String,String> e : env.entrySet()) {
-				Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: " + e.getKey() + " : " + e.getValue());
+				LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: " + e.getKey() + " : " + e.getValue());
 			}
 		}
 		
-		Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: CATALINA_HOME could not be determined. Next attempt: log4j.configuration property path");
+		LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: CATALINA_HOME could not be determined. Next attempt: log4j.configuration property path");
 		
 		String logLocation = System.getProperty("log4j.configuration");
 		if (logLocation != null) {
 			File tcHomeDir = getTeamCityHomeDir(logLocation.replaceFirst("file\\:", "").replace("../conf/teamcity-server-log4j.xml", "../"));
 			if (tcHomeDir != null) {
-				Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: TeamCity appears to be in: " + tcHomeDir.getAbsolutePath());
+				LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: TeamCity appears to be in: " + tcHomeDir.getAbsolutePath());
 				return tcHomeDir;
 			}
 		}
@@ -194,10 +194,10 @@ public class WebHookTeamCityRestApiZipPluginFixer {
 	}
 	
 	private File getTeamCityHomeDir(String filePath) {
-		Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: Trying to determine if TeamCity is in: " + filePath);
+		LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: Trying to determine if TeamCity is in: " + filePath);
 		File path = new File(filePath);
 		if (path.exists() && path.isDirectory()) {
-			Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: Checking dir contains webapps. Looking in: " + path.getAbsolutePath());
+			LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: Checking dir contains webapps. Looking in: " + path.getAbsolutePath());
 			for (File dirname : path.listFiles()) {
 				if ("webapps".equalsIgnoreCase(dirname.getName())) {
 					return path;
@@ -210,7 +210,7 @@ public class WebHookTeamCityRestApiZipPluginFixer {
 	protected boolean doesRestApiZipFileContainJaxJars(File restApiZip, String[] filenames, JarReport jarReport) throws IOException {
         // If we have a new TC version the jar conflict is resolved so just return false
 		if (mySBuildServer.getServerMajorVersion() >= 21) {
-			Loggers.SERVER.debug("TeamCity is 2021.0 or newer. Skipping ZIP file checking for " + restApiZip.getAbsolutePath());
+			LOG.debug("TeamCity is 2021.0 or newer. Skipping ZIP file checking for " + restApiZip.getAbsolutePath());
 			for (String filename : filenames) {
         		jarReport.setJarFoundInZipFile(filename, false);
 			}
@@ -227,7 +227,7 @@ public class WebHookTeamCityRestApiZipPluginFixer {
         	Path path = Paths.get(restApiZip.getAbsolutePath());
         	zipDisk = new URI("jar",path.toUri().toString(), null);
     	} catch(URISyntaxException e) {
-    		Loggers.SERVER.warn("WebHookTeamCityRestApiZipPluginFixer :: Could not convert to JAR URI.", e);
+    		LOG.warn("WebHookTeamCityRestApiZipPluginFixer :: Could not convert to JAR URI.", e);
     	}
         boolean fileFoundInZip = false;
         
@@ -244,8 +244,8 @@ public class WebHookTeamCityRestApiZipPluginFixer {
         		}
         	}
         } catch(IllegalArgumentException e) {
-        	Loggers.SERVER.error("WebHookTeamCityRestApiZipPluginFixer :: Could not create filesystem: " + e.getMessage());
-        	Loggers.SERVER.debug(e);
+        	LOG.error("WebHookTeamCityRestApiZipPluginFixer :: Could not create filesystem: " + e.getMessage());
+        	LOG.debug(e);
         }
         return fileFoundInZip;
 	}
@@ -267,7 +267,7 @@ public class WebHookTeamCityRestApiZipPluginFixer {
 				}
 			}
 		} else {
-			Loggers.SERVER.debug("WebHookTeamCityRestApiZipPluginFixer :: Unpacked dir does not exist in: " + restPluginUnpackedDir);
+			LOG.debug("WebHookTeamCityRestApiZipPluginFixer :: Unpacked dir does not exist in: " + restPluginUnpackedDir);
 		}
 		
 		return fileExists;
@@ -291,7 +291,7 @@ public class WebHookTeamCityRestApiZipPluginFixer {
 						}
 					} catch (IOException e) {
 						jarReport.setUnpackedLocationFailureMessage(filename, e.getMessage());
-						Loggers.SERVER.warnAndDebugDetails("WebHookTeamCityRestApiZipPluginFixer :: Failed to delete file from unpacked location: " + e.getMessage(), e);
+						LOG.warnAndDebugDetails("WebHookTeamCityRestApiZipPluginFixer :: Failed to delete file from unpacked location: " + e.getMessage(), e);
 					}
 				}
 			}
@@ -311,7 +311,7 @@ public class WebHookTeamCityRestApiZipPluginFixer {
         	Path path = Paths.get(restApiZip.getAbsolutePath());
         	zipDisk = new URI("jar",path.toUri().toString().replace("\\","/"), null);
     	} catch(URISyntaxException e) {
-    		Loggers.SERVER.warn("WebHookTeamCityRestApiZipPluginFixer :: Could not convert to JAR URI.", e);
+    		LOG.warn("WebHookTeamCityRestApiZipPluginFixer :: Could not convert to JAR URI.", e);
     	}
 		boolean fileDeletedInZip = false;
 		
@@ -350,14 +350,14 @@ public class WebHookTeamCityRestApiZipPluginFixer {
         if (name != null && matcher.matches(name)) {
         	matchedPaths.add(file);
             numMatches++;
-            Loggers.SERVER.debug("Found file: " + file);
+            LOG.debug("Found file: " + file);
         }
     }
 
     // Prints the total number of
     // matches to standard out.
     List<Path> getResults() {
-    	Loggers.SERVER.debug("Matched: "
+    	LOG.debug("Matched: "
             + numMatches);
         return matchedPaths;
     }
@@ -383,7 +383,7 @@ public class WebHookTeamCityRestApiZipPluginFixer {
     @Override
     public FileVisitResult visitFileFailed(Path file,
             IOException exc) {
-        Loggers.SERVER.warn("WebHookTeamCityRestApiZipPluginFixer ::Visiting file failed", exc);
+        LOG.warn("WebHookTeamCityRestApiZipPluginFixer ::Visiting file failed", exc);
         return CONTINUE;
     	}
     }

--- a/tcwebhooks-rest-api-legacy/src/main/java/webhook/teamcity/server/rest/RESTControllerExtensionInitializer.java
+++ b/tcwebhooks-rest-api-legacy/src/main/java/webhook/teamcity/server/rest/RESTControllerExtensionInitializer.java
@@ -17,20 +17,20 @@
 package webhook.teamcity.server.rest;
 
 import jetbrains.buildServer.server.rest.RESTControllerExtensionAdapter;
-
+import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.NotNull;
-
-import webhook.teamcity.Loggers;
 
 /**
  * @author Yegor.Yarko
  *         Date: 20.06.2010
  */
 public class RESTControllerExtensionInitializer extends RESTControllerExtensionAdapter {
+    private static final Logger LOG = Logger.getInstance(RESTControllerExtensionInitializer.class.getName());
+
     @Override
     @NotNull
     public String getPackage() {
-    	Loggers.SERVER.info("RESTControllerExtensionInitializer :: getPackage()");
+    	LOG.info("RESTControllerExtensionInitializer :: getPackage()");
         return "webhook.teamcity.server.rest";
     }
 }

--- a/tcwebhooks-rest-api-legacy/src/main/java/webhook/teamcity/server/rest/web/WebHookRestApiAdminPage.java
+++ b/tcwebhooks-rest-api-legacy/src/main/java/webhook/teamcity/server/rest/web/WebHookRestApiAdminPage.java
@@ -8,9 +8,8 @@ import java.util.TreeMap;
 import javax.servlet.http.HttpServletRequest;
 
 import org.jetbrains.annotations.NotNull;
-
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.controllers.admin.AdminPage;
-import jetbrains.buildServer.log.Loggers;
 import jetbrains.buildServer.serverSide.SBuildServer;
 import jetbrains.buildServer.serverSide.auth.Permission;
 import jetbrains.buildServer.web.openapi.PagePlaces;
@@ -21,6 +20,8 @@ import webhook.teamcity.server.WebHookTeamCityRestApiZipPluginFixer;
 import webhook.teamcity.server.pluginfixer.JarReport;
 
 public class WebHookRestApiAdminPage extends AdminPage {
+	private static final Logger LOG = Logger.getInstance(WebHookRestApiAdminPage.class.getName());
+
 	public static final String TC_WEB_HOOK_REST_API_ADMIN_ID = "tcWebHooksRestApi";
 	private final WebHookTeamCityRestApiZipPluginFixer myPluginFixer;
 
@@ -86,11 +87,11 @@ public class WebHookRestApiAdminPage extends AdminPage {
 	}
 
 	private boolean isRestartable(SBuildServer server) {
-		Loggers.SERVER.debug("WebHookRestApiAdminPage :: Server Major Version is: " + server.getServerMajorVersion());
-		Loggers.SERVER.debug("WebHookRestApiAdminPage :: Server Minor Version is: " + server.getServerMinorVersion());
-		Loggers.SERVER.debug("WebHookRestApiAdminPage :: Server Version is: " + server.getFullServerVersion());
+		LOG.debug("WebHookRestApiAdminPage :: Server Major Version is: " + server.getServerMajorVersion());
+		LOG.debug("WebHookRestApiAdminPage :: Server Minor Version is: " + server.getServerMinorVersion());
+		LOG.debug("WebHookRestApiAdminPage :: Server Version is: " + server.getFullServerVersion());
 		boolean isRestartable = (server.getServerMajorVersion() == 17 && server.getServerMinorVersion() >= 2) || server.getServerMajorVersion() > 17;
-		Loggers.SERVER.info("Server is restartable: " + isRestartable);
+		LOG.info("Server is restartable: " + isRestartable);
 		return isRestartable;
 	}
 

--- a/tcwebhooks-rest-api-legacy/src/test/java/webhook/teamcity/test/jerseyprovider/MockingWebHookUserRequestedExecutorProvider.java
+++ b/tcwebhooks-rest-api-legacy/src/test/java/webhook/teamcity/test/jerseyprovider/MockingWebHookUserRequestedExecutorProvider.java
@@ -18,8 +18,7 @@ import com.sun.jersey.core.spi.component.ComponentContext;
 import com.sun.jersey.core.spi.component.ComponentScope;
 import com.sun.jersey.spi.inject.Injectable;
 import com.sun.jersey.spi.inject.InjectableProvider;
-
-import jetbrains.buildServer.log.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 import webhook.WebHookExecutionStats;
 import webhook.teamcity.history.WebHookHistoryItem;
 import webhook.teamcity.settings.WebHookConfig;
@@ -29,6 +28,7 @@ import webhook.testframework.util.ConfigLoaderUtil;
 
 @Provider
 public class MockingWebHookUserRequestedExecutorProvider implements InjectableProvider<Context, Type>, Injectable<WebHookUserRequestedExecutor> {
+	private static final Logger LOG = Logger.getInstance(MockingWebHookUserRequestedExecutorProvider.class.getName());
 	private final WebHookUserRequestedExecutor request;
 
 	public MockingWebHookUserRequestedExecutorProvider() {
@@ -45,7 +45,7 @@ public class MockingWebHookUserRequestedExecutorProvider implements InjectablePr
 			webHookConfig = ConfigLoaderUtil.getFirstWebHookInConfig(
 					new File("../tcwebhooks-core/src/test/resources/project-settings-test-all-states-enabled.xml"));
 		} catch (IOException | JDOMException e1) {
-			Loggers.SERVER.debug(e1);
+			LOG.debug(e1);
 		}
 		WebHookExecutionStats stats = new WebHookExecutionStats("http://localhost/somewhere");
 		

--- a/tcwebhooks-rest-api/src/main/java/webhook/teamcity/server/rest/RESTControllerExtensionInitializer.java
+++ b/tcwebhooks-rest-api/src/main/java/webhook/teamcity/server/rest/RESTControllerExtensionInitializer.java
@@ -16,21 +16,21 @@
 
 package webhook.teamcity.server.rest;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.server.rest.RESTControllerExtensionAdapter;
-
 import org.jetbrains.annotations.NotNull;
-
-import webhook.teamcity.Loggers;
 
 /**
  * @author Yegor.Yarko
  *         Date: 20.06.2010
  */
 public class RESTControllerExtensionInitializer extends RESTControllerExtensionAdapter {
+    private static final Logger LOG = Logger.getInstance(RESTControllerExtensionInitializer.class.getName());
+
     @Override
     @NotNull
     public String getPackage() {
-    	Loggers.SERVER.info("RESTControllerExtensionInitializer :: getPackage()");
+    	LOG.info("RESTControllerExtensionInitializer :: getPackage()");
         return "webhook.teamcity.server.rest";
     }
 }

--- a/tcwebhooks-rest-api/src/main/java/webhook/teamcity/server/rest/web/WebHookRestApiAdminPage.java
+++ b/tcwebhooks-rest-api/src/main/java/webhook/teamcity/server/rest/web/WebHookRestApiAdminPage.java
@@ -7,10 +7,10 @@ import java.util.TreeMap;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import jetbrains.buildServer.controllers.admin.AdminPage;
-import jetbrains.buildServer.log.Loggers;
 import jetbrains.buildServer.serverSide.SBuildServer;
 import jetbrains.buildServer.serverSide.auth.Permission;
 import jetbrains.buildServer.web.openapi.PagePlaces;
@@ -21,6 +21,7 @@ import webhook.teamcity.server.WebHookTeamCityRestApiZipPluginFixer;
 import webhook.teamcity.server.pluginfixer.JarReport;
 
 public class WebHookRestApiAdminPage extends AdminPage {
+	private static final Logger LOG = Logger.getInstance(WebHookRestApiAdminPage.class.getName());
 	public static final String TC_WEB_HOOK_REST_API_ADMIN_ID = "tcWebHooksRestApi";
 	private final WebHookTeamCityRestApiZipPluginFixer myPluginFixer;
 
@@ -86,11 +87,11 @@ public class WebHookRestApiAdminPage extends AdminPage {
 	}
 
 	private boolean isRestartable(SBuildServer server) {
-		Loggers.SERVER.debug("WebHookRestApiAdminPage :: Server Major Version is: " + server.getServerMajorVersion());
-		Loggers.SERVER.debug("WebHookRestApiAdminPage :: Server Minor Version is: " + server.getServerMinorVersion());
-		Loggers.SERVER.debug("WebHookRestApiAdminPage :: Server Version is: " + server.getFullServerVersion());
+		LOG.debug("WebHookRestApiAdminPage :: Server Major Version is: " + server.getServerMajorVersion());
+		LOG.debug("WebHookRestApiAdminPage :: Server Minor Version is: " + server.getServerMinorVersion());
+		LOG.debug("WebHookRestApiAdminPage :: Server Version is: " + server.getFullServerVersion());
 		boolean isRestartable = (server.getServerMajorVersion() == 17 && server.getServerMinorVersion() >= 2) || server.getServerMajorVersion() > 17;
-		Loggers.SERVER.info("Server is restartable: " + isRestartable);
+		LOG.info("Server is restartable: " + isRestartable);
 		return isRestartable;
 	}
 

--- a/tcwebhooks-rest-api/src/test/java/webhook/teamcity/test/jerseyprovider/MockingWebHookUserRequestedExecutorProvider.java
+++ b/tcwebhooks-rest-api/src/test/java/webhook/teamcity/test/jerseyprovider/MockingWebHookUserRequestedExecutorProvider.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Type;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.ext.Provider;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.jdom.JDOMException;
 import org.joda.time.LocalDateTime;
 
@@ -19,7 +20,6 @@ import com.sun.jersey.core.spi.component.ComponentScope;
 import com.sun.jersey.spi.inject.Injectable;
 import com.sun.jersey.spi.inject.InjectableProvider;
 
-import jetbrains.buildServer.log.Loggers;
 import webhook.WebHookExecutionStats;
 import webhook.teamcity.history.WebHookHistoryItem;
 import webhook.teamcity.settings.WebHookConfig;
@@ -29,6 +29,7 @@ import webhook.testframework.util.ConfigLoaderUtil;
 
 @Provider
 public class MockingWebHookUserRequestedExecutorProvider implements InjectableProvider<Context, Type>, Injectable<WebHookUserRequestedExecutor> {
+	private static final Logger LOG = Logger.getInstance(MockingWebHookUserRequestedExecutorProvider.class.getName());
 	private final WebHookUserRequestedExecutor request;
 
 	public MockingWebHookUserRequestedExecutorProvider() {
@@ -45,7 +46,7 @@ public class MockingWebHookUserRequestedExecutorProvider implements InjectablePr
 			webHookConfig = ConfigLoaderUtil.getFirstWebHookInConfig(
 					new File("../tcwebhooks-core/src/test/resources/project-settings-test-all-states-enabled.xml"));
 		} catch (IOException | JDOMException e1) {
-			Loggers.SERVER.debug(e1);
+			LOG.debug(e1);
 		}
 		WebHookExecutionStats stats = new WebHookExecutionStats("http://localhost/somewhere");
 		

--- a/tcwebhooks-web-ui/src/main/java/webhook/teamcity/endpoint/WebHookEndPointController.java
+++ b/tcwebhooks-web-ui/src/main/java/webhook/teamcity/endpoint/WebHookEndPointController.java
@@ -9,6 +9,7 @@ import java.util.TreeMap;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.controllers.AuthorizationInterceptor;
 import jetbrains.buildServer.controllers.BaseController;
 import jetbrains.buildServer.serverSide.SBuildServer;
@@ -17,14 +18,13 @@ import jetbrains.buildServer.web.openapi.WebControllerManager;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.web.servlet.ModelAndView;
 
-import webhook.teamcity.Loggers;
 import webhook.teamcity.payload.format.WebHookPayloadNameValuePairs;
 import webhook.teamcity.payload.util.StringUtils;
 
 @SuppressWarnings("squid:MaximumInheritanceDepth")
 public class WebHookEndPointController extends BaseController {
-	
-	
+	private static final Logger LOG = Logger.getInstance(WebHookEndPointController.class.getName());
+
 	public static final String MY_URL = "/webhooks/endpoint.html";
 	private final WebHookEndPointContentStore endPointContentStore;
 	private final WebControllerManager myWebManager;
@@ -38,16 +38,16 @@ public class WebHookEndPointController extends BaseController {
 		this.myWebManager = webControllerManager;
 		this.myWebManager.registerController(MY_URL, this);
 		authorizationInterceptor.addPathNotRequiringAuth(MY_URL);
-		Loggers.SERVER.debug("WebHookEndPointController:: Registering");
+		LOG.debug("WebHookEndPointController:: Registering");
 	}
 
     @Nullable
     protected ModelAndView doHandle(HttpServletRequest request, HttpServletResponse response) throws Exception {
     	if (isPost(request)) {
-    		boolean debug = Loggers.SERVER.isDebugEnabled();
+    		boolean debug = LOG.isDebugEnabled();
     		
     		if (debug) { 
-    			Loggers.SERVER.debug(WebHookEndPointController.this.getClass().getName() + ":: Showing received content.");
+    			LOG.debug(WebHookEndPointController.this.getClass().getName() + ":: Showing received content.");
     		}
 			
 			// Read from request
@@ -56,7 +56,7 @@ public class WebHookEndPointController extends BaseController {
 			String line;
 			while ((line = reader.readLine()) != null) {
 				buffer.append(line);
-				if (debug) Loggers.SERVER.debug(line);
+				if (debug) LOG.debug(line);
 			}
 			
 			Map<String, String> headers = new TreeMap<>();

--- a/tcwebhooks-web-ui/src/main/java/webhook/teamcity/endpoint/WebHookEndPointViewerController.java
+++ b/tcwebhooks-web-ui/src/main/java/webhook/teamcity/endpoint/WebHookEndPointViewerController.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -15,11 +16,10 @@ import jetbrains.buildServer.controllers.BaseController;
 import jetbrains.buildServer.serverSide.SBuildServer;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
 import jetbrains.buildServer.web.openapi.WebControllerManager;
-import webhook.teamcity.Loggers;
 
 @SuppressWarnings("squid:MaximumInheritanceDepth")
 public class WebHookEndPointViewerController extends BaseController {
-	
+	private static final Logger LOG = Logger.getInstance(WebHookEndPointViewerController.class.getName());
 	
 	public static final String MY_URL = "/webhooks/endpoint-viewer.html";
 	private final WebHookEndPointContentStore endPointContentStore;
@@ -35,7 +35,7 @@ public class WebHookEndPointViewerController extends BaseController {
 		this.myPluginPath = pluginDescriptor.getPluginResourcesPath();
 		this.myWebManager = webControllerManager;
 		this.myWebManager.registerController(MY_URL, this);
-		Loggers.SERVER.debug("WebHookEndPointViewerController:: Registering");
+		LOG.debug("WebHookEndPointViewerController:: Registering");
 	}
 
     @Nullable

--- a/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/WebHookIndexPageController.java
+++ b/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/WebHookIndexPageController.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -28,7 +29,6 @@ import jetbrains.buildServer.web.util.SessionUser;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import webhook.Constants;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.TeamCityIdResolver;
 import webhook.teamcity.WebHookPluginDataResolver;
 import webhook.teamcity.auth.WebHookAuthenticatorProvider;
@@ -53,6 +53,7 @@ import webhook.teamcity.settings.project.WebHookParameterStoreFactory;
 
 @SuppressWarnings("squid:MaximumInheritanceDepth")
 public class WebHookIndexPageController extends BaseController {
+		private static final Logger LOG = Logger.getInstance(WebHookIndexPageController.class.getName());
 
 		private final WebControllerManager myWebManager;
 		private final WebHookMainSettings myMainSettings;
@@ -145,7 +146,7 @@ public class WebHookIndexPageController extends BaseController {
 
 					params.put("permissionError", "");
 					for (SProject projectParent : parentProjects){
-						Loggers.SERVER.debug("WebHookProjectSettingsTab: Assembling webhooks for project: " + projectParent.getName());
+						LOG.debug("WebHookProjectSettingsTab: Assembling webhooks for project: " + projectParent.getName());
 						if (currentProject.getProjectId().equals(projectParent.getProjectId())) {
 
 							projectBean =  ProjectWebHooksBean.buildWithoutNew(this.myWebhookSettingsManager.getWebHooksForProject(currentProject), 

--- a/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/BuildWebhooksBean.java
+++ b/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/BuildWebhooksBean.java
@@ -5,7 +5,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import jetbrains.buildServer.log.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.SBuildType;
 import webhook.teamcity.TeamCityIdResolver;
 import webhook.teamcity.history.GeneralisedWebAddress;
@@ -20,6 +20,7 @@ import webhook.teamcity.settings.WebHookConfig;
  * Used internally by {@link ProjectAndBuildWebhooksBean} only. Don't instantiate manually.
  */
 public class BuildWebhooksBean{
+	private static final Logger LOG = Logger.getInstance(BuildWebhooksBean.class.getName());
 
 	private SBuildType sBuildType;
 	private List<WebHookConfigWithGeneralisedAddressWrapper> buildConfigs;
@@ -60,7 +61,7 @@ public class BuildWebhooksBean{
 			try {
 				url = new URL(uri);
 			} catch (MalformedURLException e) {
-				Loggers.SERVER.warn("BuildWebhooksBean :: Could not build URL from '" + url + "'" );
+				LOG.warn("BuildWebhooksBean :: Could not build URL from '" + url + "'" );
 				try {
 					url = new URL("http://unknown");
 				} catch (MalformedURLException e1) {}

--- a/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/ProjectAndBuildWebhooksBean.java
+++ b/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/ProjectAndBuildWebhooksBean.java
@@ -5,7 +5,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import jetbrains.buildServer.log.Loggers;
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.SBuildType;
 import jetbrains.buildServer.serverSide.SProject;
 import webhook.Constants;
@@ -22,6 +22,7 @@ import webhook.teamcity.settings.WebHookProjectSettings;
  *
  */
 public class ProjectAndBuildWebhooksBean {
+	private static final Logger LOG = Logger.getInstance(ProjectAndBuildWebhooksBean.class.getName());
 	SProject project;
 	boolean isAdmin;
 	WebHookProjectSettings webHookProjectSettings;
@@ -117,7 +118,7 @@ public class ProjectAndBuildWebhooksBean {
 			try {
 				url = new URL(uri);
 			} catch (MalformedURLException e) {
-				Loggers.SERVER.warn("BuildWebhooksBean :: Could not build URL from '" + url + "'" );
+				LOG.warn("BuildWebhooksBean :: Could not build URL from '" + url + "'" );
 				try {
 					url = new URL("http://unknown");
 				} catch (MalformedURLException e1) {

--- a/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/template/RegisteredWebHookTemplateBean.java
+++ b/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/bean/template/RegisteredWebHookTemplateBean.java
@@ -6,11 +6,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.intellij.openapi.diagnostic.Logger;
 import jetbrains.buildServer.serverSide.ProjectManager;
 import jetbrains.buildServer.serverSide.SProject;
 import webhook.Constants;
 import webhook.teamcity.BuildStateEnum;
-import webhook.teamcity.Loggers;
 import webhook.teamcity.payload.WebHookPayload;
 import webhook.teamcity.payload.WebHookPayloadTemplate;
 import webhook.teamcity.payload.WebHookTemplateManager;
@@ -18,7 +18,8 @@ import webhook.teamcity.payload.WebHookTemplateManager.TemplateState;
 import webhook.teamcity.settings.WebHookSettingsManager;
 
 public class RegisteredWebHookTemplateBean {
-	
+	private static final Logger LOG = Logger.getInstance(RegisteredWebHookTemplateBean.class.getName());
+
 	Map<String,SimpleTemplate> templateList = new LinkedHashMap<>();
 
 	public static RegisteredWebHookTemplateBean build(
@@ -60,7 +61,7 @@ public class RegisteredWebHookTemplateBean {
 				}
 			}
 			if (! validTemplate) {
-				Loggers.SERVER.warn("RegisteredWebHookTemplateBean :: template does not appear to be valid: " + t.getTemplateDescription() + " (" + t.getTemplateId() + ")");
+				LOG.warn("RegisteredWebHookTemplateBean :: template does not appear to be valid: " + t.getTemplateDescription() + " (" + t.getTemplateId() + ")");
 			}
 		}
 		return bean;

--- a/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/project/WebHookProjectSettingsTab.java
+++ b/tcwebhooks-web-ui/src/main/java/webhook/teamcity/extension/project/WebHookProjectSettingsTab.java
@@ -10,10 +10,10 @@ import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import jetbrains.buildServer.controllers.admin.projects.EditProjectTab;
-import jetbrains.buildServer.log.Loggers;
 import jetbrains.buildServer.serverSide.ProjectManager;
 import jetbrains.buildServer.serverSide.SProject;
 import jetbrains.buildServer.web.openapi.PagePlaces;
@@ -41,6 +41,7 @@ import webhook.teamcity.settings.project.WebHookParameterStore;
 import webhook.teamcity.settings.project.WebHookParameterStoreFactory;
 
 public class WebHookProjectSettingsTab extends EditProjectTab {
+	private static final Logger LOG = Logger.getInstance(WebHookProjectSettingsTab.class.getName());
 	private static final String TAB_TITLE = "WebHooks & Templates";
 	private final WebHookSettingsManager myWebhookSettingsManager;
 	private final WebHookPayloadManager myPayloadManager;
@@ -130,7 +131,7 @@ public class WebHookProjectSettingsTab extends EditProjectTab {
 
 		model.put("permissionError", "");
 		for (SProject projectParent : parentProjects){
-			Loggers.SERVER.debug("WebHookProjectSettingsTab: Assembling webhooks for project: " + projectParent.getName());
+			LOG.debug("WebHookProjectSettingsTab: Assembling webhooks for project: " + projectParent.getName());
 			if (currentProject.getProjectId().equals(projectParent.getProjectId())) {
 
 				projectBean =  ProjectWebHooksBean.buildWithoutNew(this.myWebhookSettingsManager.getWebHooksForProject(currentProject), 


### PR DESCRIPTION
Hey @netwolfuk 

We're facing an odd issue where webhooks are randomly being deleted. Trying to debug it is a bit of a pain, as the logs just end up in `teamcity-server.log`, so it's hard to parse which ones are related to this plugin.

I propose (a potentially controversial solution) to change all the loggers to class specific loggers, then we can add log settings to redirect it to it's own file (via the `conf/teamcity-server-log4j.xml`):

```
<Appenders>
    <DelegateAppender>
      <RollingFile name="tcWebHooks.LOG" fileName="${sys:teamcity_logs}/teamcity-tcwebhooks-plugin.log"
                   filePattern="${sys:teamcity_logs}/teamcity-tcwebhooks-plugin.log.%i"
                   append="true" createOnDemand="true">
        <PatternLayout pattern="[%d] %6p - %30.30c - %X - %m%n" charset="UTF-8"/>
        <SizeBasedTriggeringPolicy size="10 MB"/>
        <DefaultRolloverStrategy max="3" fileIndex="min"/>
      </RollingFile>
    </DelegateAppender>
</Appenders>
```

```
<Loggers>
   <Logger name="webhook" level="DEBUG" additivity="false">
      <AppenderRef ref="tcWebHooks.LOG" />
    </Logger>
</Loggers>
```

This gives:
![image](https://github.com/user-attachments/assets/8a8a9e6d-2c26-4f85-b627-143d9943bfbf)


This is the pattern we use for our own plugins (eg http://github.com/octopusdeploy/teamcity-opentelemetry-plugin), and it works pretty well.

What do you think?